### PR TITLE
Initial Maui.Markup overview

### DIFF
--- a/docs/maui/TOC.yml
+++ b/docs/maui/TOC.yml
@@ -5,3 +5,7 @@ items:
   items:
     - name: Get started
       href: get-started.md
+- name: Markup
+  items:
+    - name: C# Markup
+      href: markup/markup.md

--- a/docs/maui/TOC.yml
+++ b/docs/maui/TOC.yml
@@ -5,7 +5,7 @@ items:
   items:
     - name: Get started
       href: get-started.md
-- name: Markup
+- name: C# Markup
   items:
-    - name: C# Markup
+    - name: Overview
       href: markup/markup.md

--- a/docs/maui/markup/markup.md
+++ b/docs/maui/markup/markup.md
@@ -21,7 +21,7 @@ The C# Markup package can be included in your project(s) as decribed in our [Get
 
 ## Example
 
-The following example shows setting the page content to a new [`Grid`](xref:Microsoft.Maui.Controls.Grid) containing a [`Label`](xref:Microsoft.Maui.Controls.Label) and an [`Entry`](xref:Microsoft.Maui.Controls.Entry), in C#:
+The following example shows setting the page content to a new `Grid` containing a `Label` and an `Entry`, in C#:
 
 ```csharp
 Grid grid = new Grid();
@@ -49,7 +49,7 @@ entry.SetBinding(Entry.TextProperty, new Binding(nameof(ViewModel.RegistrationCo
 Content = grid;
 ```
 
-This example creates a [`Grid`](xref:Microsoft.Maui.Controls.Grid) object, with child [`Label`](xref:Microsoft.Maui.Controls.Label) and [`Entry`](xref:Microsoft.Maui.Controls.Entry) objects. The `Label` displays text, and the `Entry` data binds to the `RegistrationCode` property of the viewmodel. Each child view is set to appear in a specific row in the `Grid`, and the `Entry` spans all the columns in the `Grid`. In addition, the height of the `Entry` is set, along with its keyboard, colors, the font size of its text, and its `Margin`. Finally, the `Page.Content` property is set to the `Grid` object.
+This example creates a `Grid` object, with child `Label` and `Entry` objects. The `Label` displays text, and the `Entry` data binds to the `RegistrationCode` property of the viewmodel. Each child view is set to appear in a specific row in the `Grid`, and the `Entry` spans all the columns in the `Grid`. In addition, the height of the `Entry` is set, along with its keyboard, colors, the font size of its text, and its `Margin`. Finally, the `Page.Content` property is set to the `Grid` object.
 
 C# Markup enables this code to be re-written using its fluent API:
 

--- a/docs/maui/markup/markup.md
+++ b/docs/maui/markup/markup.md
@@ -7,6 +7,8 @@ ms.date: 02/13/2022
 
 # C# Markup
 
+## Overview
+
 C# Markup is a set of fluent helper methods and classes designed to simplify the process of building declarative .NET Multi-platform App UI (.NET MAUI) user interfaces in code. The fluent API provided by C# Markup is available in the `CommunityToolkit.Maui.Markup` namespace.
 
 [!INCLUDE [docs under construction](../includes/preview-note.md)]
@@ -24,41 +26,47 @@ The C# Markup package can be included in your project(s) as decribed in our [Get
 The following example shows setting the page content to a new `Grid` containing a `Label` and an `Entry`, in C#:
 
 ```csharp
-Grid grid = new Grid
+class SampleContentPage : ContentPage
 {
-    RowDefinitions =
+    public SampleContentPage()
     {
-        new RowDefinition { Height = new GridLength(36, GridUnitType.Absolute) }
-    },
+        Grid grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(36, GridUnitType.Absolute) }
+            },
 
-    ColumnDefinitions =
-    {
-        new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
-        new ColumnDefinition { Width = new GridLength(2, GridUnitType.Star) }
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = new GridLength(2, GridUnitType.Star) }
+            }
+        }
+
+        Label label = new Label { Text = "Code: " };
+        grid.Children.Add(label);
+        GridLayout.SetColumn(label, 0);
+        GridLayout.SetRow(label, 0);
+
+        Entry entry = new Entry
+        {
+            Placeholder = "Enter number",
+            Keyboard = Keyboard.Numeric,
+            BackgroundColor = Colors.AliceBlue,
+            TextColor = Colors.Black,
+            FontSize = 15,
+            HeightRequest = 44,
+            Margin = new Thickness(5)
+        };
+        grid.Children.Add(entry);
+        GridLayout.SetColumn(label, 1);
+        GridLayout.SetRow(label, 0);
+        entry.SetBinding(Entry.TextProperty, new Binding(nameof(ViewModel.RegistrationCode));
+
+        Content = grid;
     }
 }
-
-Label label = new Label { Text = "Code: " };
-grid.Children.Add(label);
-GridLayout.SetColumn(label, 0);
-GridLayout.SetRow(label, 0);
-
-Entry entry = new Entry
-{
-    Placeholder = "Enter number",
-    Keyboard = Keyboard.Numeric,
-    BackgroundColor = Colors.AliceBlue,
-    TextColor = Colors.Black,
-    FontSize = 15,
-    HeightRequest = 44,
-    Margin = new Thickness(5)
-};
-grid.Children.Add(entry);
-GridLayout.SetColumn(label, 1);
-GridLayout.SetRow(label, 0);
-entry.SetBinding(Entry.TextProperty, new Binding(nameof(ViewModel.RegistrationCode));
-
-Content = grid;
 ```
 
 This example creates a `Grid` object, with child `Label` and `Entry` objects. The `Label` displays text, and the `Entry` data binds to the `RegistrationCode` property of the viewmodel. Each child view is set to appear in a specific row in the `Grid`, and the `Entry` spans all the columns in the `Grid`. In addition, the height of the `Entry` is set, along with its keyboard, colors, the font size of its text, and its `Margin`. Finally, the `Page.Content` property is set to the `Grid` object.

--- a/docs/maui/markup/markup.md
+++ b/docs/maui/markup/markup.md
@@ -11,7 +11,7 @@ C# Markup is a set of fluent helper methods and classes designed to simplify the
 
 [!INCLUDE [docs under construction](../includes/preview-note.md)]
 
-Just as with XAML, C# Markup enables a clean separation between UI markup and UI logic. This can be achieved by separating UI markup and UI logic into distinct partial class files. For example, for a login page the UI markup would be in a file named `LoginPage.cs`, while the UI logic would be in a file named `LoginPage.logic.cs`.
+Just as with XAML, C# Markup enables a clean separation between UI (View)) and Business Logic (View Model).
 
 C# Markup is available on all platforms supported by .NET MAUI.
 
@@ -24,7 +24,19 @@ The C# Markup package can be included in your project(s) as decribed in our [Get
 The following example shows setting the page content to a new `Grid` containing a `Label` and an `Entry`, in C#:
 
 ```csharp
-Grid grid = new Grid();
+Grid grid = new Grid
+{
+    RowDefinitions =
+    {
+        new RowDefinition { Height = new GridLength(36, GridUnitType.Absolute) }
+    },
+
+    ColumnDefinitions =
+    {
+        new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+        new ColumnDefinition { Width = new GridLength(2, GridUnitType.Star) }
+    }
+}
 
 Label label = new Label { Text = "Code: " };
 grid.Children.Add(label);
@@ -62,15 +74,15 @@ class SampleContentPage : ContentPage
     {
         Content = new Grid
         {
+            RowDefinitions = Rows.Define(
+                (Row.TextEntry, 36)),
+
+            ColumnDefinitions = Columns.Define(
+                (Column.Description, Star),
+                (Column.Input, Stars(2))),
+
             Children =
             {
-                RowDefinitions = Rows.Define(
-                    (Row.TextEntry, 36)),
-
-                ColumnDefinitions = Columns.Define(
-                    (Column.Description, Star),
-                    (Column.Input, Stars(2))),
-
                 new Label { Text = "Code:" }
                     .Row(Row.TextEntry).Column(Column.Description),
 

--- a/docs/maui/markup/markup.md
+++ b/docs/maui/markup/markup.md
@@ -54,33 +54,50 @@ This example creates a `Grid` object, with child `Label` and `Entry` objects. Th
 C# Markup enables this code to be re-written using its fluent API:
 
 ```csharp
-Content = new Grid
-{
-    Children =
-    {
-        new Label { Text = "Code:" }
-            .Column(0)
-            .Row(0),
+using static CommunityToolkit.Maui.Markup.GridRowsColumns;
 
-        new Entry
+class SampleContentPage : ContentPage
+{
+    public SampleContentPage()
+    {
+        Content = new Grid
+        {
+            Children =
             {
-                Placeholder = "Enter number",
-                Keyboard = Keyboard.Numeric,
-                BackgroundColor = Colors.AliceBlue,
-                TextColor = Colors.Black
+                RowDefinitions = Rows.Define(
+                    (Row.TextEntry, Auto)),
+
+                ColumnDefinitions = Columns.Define(
+                    (Column.Description, Star),
+                    (Column.Input, Stars(2))),
+
+                new Label { Text = "Code:" }
+                    .Row(Row.TextEntry).Column(Column.Description),
+
+                new Entry
+                {
+                    Placeholder = "Enter number",
+                    Keyboard = Keyboard.Numeric,
+                    BackgroundColor = Colors.AliceBlue,
+                    TextColor = Colors.Black
+                }.Row(Row.TextEntry).Column(Column.Input)
+                 .FontSize(15)
+                 .Height(44)
+                 .Margin(5, 5)
+                 .Bind(Entry.TextProperty, nameof(ViewModel.RegistrationCode))
             }
-            .FontSize(15)
-            .Height(44)
-            .Margin(5, 5)
-            .Column(1)
-            .Row(0)
-            .Bind(Entry.TextProperty, nameof(ViewModel.RegistrationCode))
+        };
     }
-};
+
+    enum Row { TextEntry }
+    enum Column { Description, Input }
+}
 ```
 
-This example is identical to the previous example, but the C# Markup fluent API simplifies the process of building the UI in C#.
+This example is identical to the previous example, but the C# Markup fluent API simplifies the process of building the UI in C#. 
+
+C# Markup extensions also allow developers to use an `enum` to define names for Columns and Rows (e.g. `Column.Input`).
 
 
 > [!NOTE]
-> C# Markup includes extension methods that set specific view properties. These extension methods are not meant to replace all property setters. Instead, they are designed to improve code readability, and can be used in combination with property setters. It's recommended to always use an extension method when one exists for a property, but you can choose your preferred balance.
+> C# Markup includes extension methods that set specific view properties. They are designed to improve code readability, and can be used in combination with property setters. It's recommended to always use an extension method when one exists for a property, but you can choose your preferred balance.

--- a/docs/maui/markup/markup.md
+++ b/docs/maui/markup/markup.md
@@ -1,0 +1,84 @@
+---
+title: .NET MAUI Community Toolkit - Markup
+author: bijington
+description: The .NET MAUI Community Toolkit is a collection of reusable elements for application development with .NET MAUI, including animations, behaviors, converters, effects, and helpers.
+ms.date: 02/13/2022
+---
+
+# C# Markup
+
+C# Markup is a set of fluent helper methods and classes designed to simplify the process of building declarative .NET Multi-platform App UI (.NET MAUI) user interfaces in C#. The fluent API provided by C# Markup is available in the `CommunityToolkit.Maui.Markup` namespace.
+
+Just as with XAML, C# Markup enables a clean separation between UI markup and UI logic. This can be achieved by separating UI markup and UI logic into distinct partial class files. For example, for a login page the UI markup would be in a file named `LoginPage.cs`, while the UI logic would be in a file named `LoginPage.logic.cs`.
+
+C# Markup is available on all platforms supported by .NET MAUI.
+
+## NuGet package
+
+The C# Markup package can be included in your project(s) as decribed in our [Getting started](../get-started.md#communitytoolkitmauimarkup) guide.
+
+## Example
+
+The following example shows setting the page content to a new [`Grid`](xref:Microsoft.Maui.Controls.Grid) containing a [`Label`](xref:Microsoft.Maui.Controls.Label) and an [`Entry`](xref:Microsoft.Maui.Controls.Entry), in C#:
+
+```csharp
+Grid grid = new Grid();
+
+Label label = new Label { Text = "Code: " };
+grid.Children.Add(label);
+GridLayout.SetColumn(label, 0);
+GridLayout.SetRow(label, 0);
+
+Entry entry = new Entry
+{
+    Placeholder = "Enter number",
+    Keyboard = Keyboard.Numeric,
+    BackgroundColor = Colors.AliceBlue,
+    TextColor = Colors.Black,
+    FontSize = 15,
+    HeightRequest = 44,
+    Margin = new Thickness(5)
+};
+grid.Children.Add(entry);
+GridLayout.SetColumn(label, 1);
+GridLayout.SetRow(label, 0);
+entry.SetBinding(Entry.TextProperty, new Binding(nameof(ViewModel.RegistrationCode));
+
+Content = grid;
+```
+
+This example creates a [`Grid`](xref:Microsoft.Maui.Controls.Grid) object, with child [`Label`](xref:Microsoft.Maui.Controls.Label) and [`Entry`](xref:Microsoft.Maui.Controls.Entry) objects. The `Label` displays text, and the `Entry` data binds to the `RegistrationCode` property of the viewmodel. Each child view is set to appear in a specific row in the `Grid`, and the `Entry` spans all the columns in the `Grid`. In addition, the height of the `Entry` is set, along with its keyboard, colors, the font size of its text, and its `Margin`. Finally, the `Page.Content` property is set to the `Grid` object.
+
+C# Markup enables this code to be re-written using its fluent API:
+
+```csharp
+Content = new Grid
+{
+    Children =
+    {
+        new Label { Text = "Code:" }
+            .Column(0)
+            .Row(0),
+
+        new Entry
+            {
+                Placeholder = "Enter number",
+                Keyboard = Keyboard.Numeric,
+                BackgroundColor = Colors.AliceBlue,
+                TextColor = Colors.Black
+            }
+            .FontSize(15)
+            .Height(44)
+            .Margin(5, 5)
+            .Column(1)
+            .Row(0)
+            .Bind(Entry.TextProperty, nameof(ViewModel.RegistrationCode))
+    }
+};
+```
+
+This example is identical to the previous example, but the C# Markup fluent API simplifies the process of building the UI in C#.
+
+
+> [!NOTE]
+> C# Markup includes extension methods that set specific view properties. These extension methods are not meant to replace all property setters. Instead, they are designed to improve code readability, and can be used in combination with property setters. It's recommended to always use an extension method when one exists for a property, but you can choose your preferred balance.

--- a/docs/maui/markup/markup.md
+++ b/docs/maui/markup/markup.md
@@ -65,7 +65,7 @@ class SampleContentPage : ContentPage
             Children =
             {
                 RowDefinitions = Rows.Define(
-                    (Row.TextEntry, Auto)),
+                    (Row.TextEntry, 36)),
 
                 ColumnDefinitions = Columns.Define(
                     (Column.Description, Star),

--- a/docs/maui/markup/markup.md
+++ b/docs/maui/markup/markup.md
@@ -1,13 +1,15 @@
 ---
 title: .NET MAUI Community Toolkit - Markup
 author: bijington
-description: The .NET MAUI Community Toolkit is a collection of reusable elements for application development with .NET MAUI, including animations, behaviors, converters, effects, and helpers.
+description: C# Markup is a set of fluent helper methods and classes designed to simplify the process of building declarative .NET Multi-platform App UI (.NET MAUI) user interfaces in code.
 ms.date: 02/13/2022
 ---
 
 # C# Markup
 
-C# Markup is a set of fluent helper methods and classes designed to simplify the process of building declarative .NET Multi-platform App UI (.NET MAUI) user interfaces in C#. The fluent API provided by C# Markup is available in the `CommunityToolkit.Maui.Markup` namespace.
+C# Markup is a set of fluent helper methods and classes designed to simplify the process of building declarative .NET Multi-platform App UI (.NET MAUI) user interfaces in code. The fluent API provided by C# Markup is available in the `CommunityToolkit.Maui.Markup` namespace.
+
+[!INCLUDE [docs under construction](includes/preview-note.md)]
 
 Just as with XAML, C# Markup enables a clean separation between UI markup and UI logic. This can be achieved by separating UI markup and UI logic into distinct partial class files. For example, for a login page the UI markup would be in a file named `LoginPage.cs`, while the UI logic would be in a file named `LoginPage.logic.cs`.
 

--- a/docs/maui/markup/markup.md
+++ b/docs/maui/markup/markup.md
@@ -9,7 +9,7 @@ ms.date: 02/13/2022
 
 C# Markup is a set of fluent helper methods and classes designed to simplify the process of building declarative .NET Multi-platform App UI (.NET MAUI) user interfaces in code. The fluent API provided by C# Markup is available in the `CommunityToolkit.Maui.Markup` namespace.
 
-[!INCLUDE [docs under construction](includes/preview-note.md)]
+[!INCLUDE [docs under construction](../includes/preview-note.md)]
 
 Just as with XAML, C# Markup enables a clean separation between UI markup and UI logic. This can be achieved by separating UI markup and UI logic into distinct partial class files. For example, for a login page the UI markup would be in a file named `LoginPage.cs`, while the UI logic would be in a file named `LoginPage.logic.cs`.
 


### PR DESCRIPTION
Adding an overview of the CommunityToolkit.Maui.Markup package ready for the rest of the content to follow.

This PR is based off the content at: https://docs.microsoft.com/en-gb/xamarin/community-toolkit/markup with the following differences:

- Migrate from Xamarin.Forms to Maui details.
- Only focus on an overview allowing us to dive in to more specific topics (e.g. Data binding, etc.) in separate pages