### PR TITLE
Trying out a landing page for Converters

### DIFF
--- a/docs/maui/TOC.yml
+++ b/docs/maui/TOC.yml
@@ -11,6 +11,8 @@ items:
       href: behaviors/maximum-length-reached-behavior.md
 - name: "Converters"
   items:
+    - name: Converters
+      href: index.md
     - name: "EqualConverter"
       href: converters/equal-converter.md
     - name: "IsListNotNullOrEmptyConverter"

--- a/docs/maui/TOC.yml
+++ b/docs/maui/TOC.yml
@@ -12,7 +12,7 @@ items:
 - name: "Converters"
   items:
     - name: Overview
-      href: index.md
+      href: converters/index.md
     - name: "DoubleToIntConverter"
       href: converters/double-to-int-converter.md
     - name: "EqualConverter"

--- a/docs/maui/converters/index.md
+++ b/docs/maui/converters/index.md
@@ -7,8 +7,6 @@ ms.date: 03/13/2022
 
 # Converters
 
-## What is a Converter?
-
 .NET Multi-platform App UI (.NET MAUI) data bindings usually transfer data from a source property to a target property, and in some cases from the target property to the source property. This transfer is straightforward when the source and target properties are of the same type, or when one type can be converted to the other type through an implicit conversion. When that is not the case, a type conversion must take place.
 
 For further information on Converters please refer to the [.NET MAUI documentation](/dotnet/maui/fundamentals/data-binding/converters).

--- a/docs/maui/converters/index.md
+++ b/docs/maui/converters/index.md
@@ -1,0 +1,23 @@
+---
+title: Converters - .NET MAUI Community Toolkit
+author: bijington
+description: The .NET MAUI Community Toolkit is a collection of reusable elements for application development with .NET MAUI, including animations, behaviors, converters, effects, and helpers.
+ms.date: 03/13/2022
+---
+
+# What is a Converter?
+
+.NET Multi-platform App UI (.NET MAUI) data bindings usually transfer data from a source property to a target property, and in some cases from the target property to the source property. This transfer is straightforward when the source and target properties are of the same type, or when one type can be converted to the other type through an implicit conversion. When that is not the case, a type conversion must take place.
+
+For further information on Converters please refer to the [.NET MAUI documentation](https://docs.microsoft.com/en-gb/dotnet/maui/fundamentals/data-binding/converters).
+
+# .NET MAUI Community Toolkit Converters
+
+The .NET MAUI Community Toolkit provides a collection of pre-built, reusable converters to make developers lives easier. Here are the converters provided by the toolkit:
+
+| Converter | Description |
+| --------- | ----------- |
+| [`EqualConverter`](equal-converter.md) | The `EqualConverter` is a one way converter that returns a `bool` indicating whether the binding value is equal to another specified value. |
+| [`IsListNotNullOrEmptyConverter`](is-list-not-null-or-empty-converter.md) | The `IsListNotNullOrEmptyConverter` is a one way converter that converts `IEnumerable` to a `bool` value. |
+| [`IsListNullOrEmptyConverter`](is-list-null-or-empty-converter.md) | The `IsListNullOrEmptyConverter` is a one way converter that converts `IEnumerable` to a `bool` value. |
+| [`NotEqualConverter`](not-equal-converter.md) | The `NotEqualConverter` is a one way converter that returns a `bool` indicating whether the binding value is not equal to another specified value. |

--- a/docs/maui/converters/index.md
+++ b/docs/maui/converters/index.md
@@ -17,7 +17,9 @@ The .NET MAUI Community Toolkit provides a collection of pre-built, reusable con
 
 | Converter | Description |
 | --------- | ----------- |
+| [`DoubleToIntConverter`](double-to-int-converter.md) | The `DoubleToIntConverter` is a converter that allows users to convert an incoming `double` value to an `int` and vice-versa. Optionally the user can provide a multiplier to the conversion through the `Ratio` property. |
 | [`EqualConverter`](equal-converter.md) | The `EqualConverter` is a one way converter that returns a `bool` indicating whether the binding value is equal to another specified value. |
 | [`IsListNotNullOrEmptyConverter`](is-list-not-null-or-empty-converter.md) | The `IsListNotNullOrEmptyConverter` is a one way converter that converts `IEnumerable` to a `bool` value. |
 | [`IsListNullOrEmptyConverter`](is-list-null-or-empty-converter.md) | The `IsListNullOrEmptyConverter` is a one way converter that converts `IEnumerable` to a `bool` value. |
 | [`NotEqualConverter`](not-equal-converter.md) | The `NotEqualConverter` is a one way converter that returns a `bool` indicating whether the binding value is not equal to another specified value. |
+| [`TextCaseConverter`](text-case-converter.md) | The `TextCaseConverter` is a one way converter that allows users to convert the casing of an incoming `string` type binding. The `Type` property is used to define what kind of casing will be applied to the string. |

--- a/docs/maui/converters/index.md
+++ b/docs/maui/converters/index.md
@@ -1,17 +1,19 @@
 ---
 title: Converters - .NET MAUI Community Toolkit
 author: bijington
-description: The .NET MAUI Community Toolkit is a collection of reusable elements for application development with .NET MAUI, including animations, behaviors, converters, effects, and helpers.
+description: The .NET MAUI Community Toolkit provides a collection of pre-built, reusable converters to make developers lives easier.
 ms.date: 03/13/2022
 ---
 
-# What is a Converter?
+# Converters
+
+## What is a Converter?
 
 .NET Multi-platform App UI (.NET MAUI) data bindings usually transfer data from a source property to a target property, and in some cases from the target property to the source property. This transfer is straightforward when the source and target properties are of the same type, or when one type can be converted to the other type through an implicit conversion. When that is not the case, a type conversion must take place.
 
 For further information on Converters please refer to the [.NET MAUI documentation](/dotnet/maui/fundamentals/data-binding/converters).
 
-# .NET MAUI Community Toolkit Converters
+## .NET MAUI Community Toolkit Converters
 
 The .NET MAUI Community Toolkit provides a collection of pre-built, reusable converters to make developers lives easier. Here are the converters provided by the toolkit:
 

--- a/docs/maui/converters/index.md
+++ b/docs/maui/converters/index.md
@@ -9,7 +9,7 @@ ms.date: 03/13/2022
 
 .NET Multi-platform App UI (.NET MAUI) data bindings usually transfer data from a source property to a target property, and in some cases from the target property to the source property. This transfer is straightforward when the source and target properties are of the same type, or when one type can be converted to the other type through an implicit conversion. When that is not the case, a type conversion must take place.
 
-For further information on Converters please refer to the [.NET MAUI documentation](https://docs.microsoft.com/en-gb/dotnet/maui/fundamentals/data-binding/converters).
+For further information on Converters please refer to the [.NET MAUI documentation](https://docs.microsoft.com/dotnet/maui/fundamentals/data-binding/converters).
 
 # .NET MAUI Community Toolkit Converters
 

--- a/docs/maui/converters/index.md
+++ b/docs/maui/converters/index.md
@@ -9,7 +9,7 @@ ms.date: 03/13/2022
 
 .NET Multi-platform App UI (.NET MAUI) data bindings usually transfer data from a source property to a target property, and in some cases from the target property to the source property. This transfer is straightforward when the source and target properties are of the same type, or when one type can be converted to the other type through an implicit conversion. When that is not the case, a type conversion must take place.
 
-For further information on Converters please refer to the [.NET MAUI documentation](https://docs.microsoft.com/dotnet/maui/fundamentals/data-binding/converters).
+For further information on Converters please refer to the [.NET MAUI documentation](/dotnet/maui/fundamentals/data-binding/converters).
 
 # .NET MAUI Community Toolkit Converters
 


### PR DESCRIPTION
@davidbritch @brminnick @jfversluis

Just trying out a landing page for converters that links over to the .NET MAUI docs. The links in the table currently link to our written docs but I suspect these could quite easily link out to the API docs instead. What do you think?