### PR TITLE
Create element-extensions.md

### DIFF
--- a/docs/maui/TOC.yml
+++ b/docs/maui/TOC.yml
@@ -65,9 +65,11 @@ items:
   items:
     - name: Overview
       href: markup/markup.md
-    - name: "AbsoluteLayout extensions"
+    - name: "AbsoluteLayout Extensions"
       href: markup/extensions/absolute-layout-extensions.md
-    - name: "BindableObject extensions"
+    - name: "BindableObject Extensions"
       href: markup/extensions/bindable-object-extensions.md
+    - name: "Element Extensions"
+      href: markup/extensions/element-extensions.md
     - name: "VisualElement Extensions"
       href: markup/extensions/visual-element-extensions.md

--- a/docs/maui/TOC.yml
+++ b/docs/maui/TOC.yml
@@ -65,11 +65,11 @@ items:
   items:
     - name: Overview
       href: markup/markup.md
-    - name: "AbsoluteLayout Extensions"
+    - name: "AbsoluteLayout extensions"
       href: markup/extensions/absolute-layout-extensions.md
-    - name: "BindableObject Extensions"
+    - name: "BindableObject extensions"
       href: markup/extensions/bindable-object-extensions.md
-    - name: "Element Extensions"
+    - name: "Element extensions"
       href: markup/extensions/element-extensions.md
-    - name: "VisualElement Extensions"
+    - name: "VisualElement extensions"
       href: markup/extensions/visual-element-extensions.md

--- a/docs/maui/markup/extensions/element-extensions.md
+++ b/docs/maui/markup/extensions/element-extensions.md
@@ -9,7 +9,7 @@ ms.date: 03/28/2022
 
 [!INCLUDE [docs under construction](../../includes/preview-note.md)]
 
-The `Element` extensions provide a series of extension methods that support configuring the sizing, styling and behaviors of a `Element`.
+The `Element` extensions provide a series of extension methods that support configuring the padding, effects, font attributes, dynamic resources, text, and text color of an `Element`.
 
 The extensions offer the following methods:
 

--- a/docs/maui/markup/extensions/element-extensions.md
+++ b/docs/maui/markup/extensions/element-extensions.md
@@ -5,7 +5,7 @@ description: The Element extensions provide a series of extension methods that s
 ms.date: 03/28/2022
 ---
 
-# Element Extensions
+# Element extensions
 
 [!INCLUDE [docs under construction](../../includes/preview-note.md)]
 

--- a/docs/maui/markup/extensions/element-extensions.md
+++ b/docs/maui/markup/extensions/element-extensions.md
@@ -1,0 +1,124 @@
+---
+title: Element Extensions - .NET MAUI Community Toolkit
+author: brminnick
+description: The Element extensions provide a series of extension methods that support configuring the sizing, styling and behaviors of an Element.
+ms.date: 03/28/2022
+---
+
+# Element Extensions
+
+[!INCLUDE [docs under construction](../../includes/preview-note.md)]
+
+The `Element` extensions provide a series of extension methods that support configuring the sizing, styling and behaviors of a `Element`.
+
+The extensions offer the following methods:
+
+## Padding
+
+The `Padding` method sets the `Padding` property on an `IPaddingElement`.
+
+The following example sets the `Padding` to `new Thickness(5, 10)`:
+
+```csharp
+new Button().Padding(5, 10);
+```
+
+The following examples set the `Padding` to `new Thickness(10, 20, 30, 40)`:
+
+```csharp
+new Button().Padding(new Thickness(10, 20, 30, 40));
+```
+
+```csharp
+new Button().Paddings(10, 20, 30, 40);
+```
+
+## RemoveDynamicResources
+
+The `RemoveDynamicResources` method removes all dynamic resources from a specified `BindableObject`.
+
+The following example removes the `DynamicResource` from the `BackgroundColorProperty` and `TextColorProperty`:
+
+```csharp
+var button = new Button().DynamicResources(
+    (Button.BackgroundColorProperty, "ButtonBackgroundColor"),
+    (Button.TextColorProperty, "ButtonTextColor"));
+
+button.RemoveDynamicResources(Button.BackgroundColorProperty, Button.TextColorProperty);
+```
+
+## Effects
+
+The `Effects` method attaches the provided `Effect` to an `Element`.
+
+The following example attaches the `ShadowEffect` and `TouchEffect` to the `Element`:
+
+```csharp
+new Button().Effects(new ShadowEffect(), new TouchEffect());
+```
+
+## Font Size
+
+The `FontSize` method sets the `FontSize` property on an `IFontElement` element.
+
+The following example sets the `FontSize` to `12`:
+
+```csharp
+new Button().FontSize(12);
+```
+
+## Bold
+
+The `Bold` method sets `FontAttributes = FontAttributes.Bold` on an `IFontElement` element.
+
+The following example sets the button font to bold:
+
+```csharp
+new Button().Bold()
+```
+
+## Italic
+
+The `Italic` method sets `FontAttributes = FontAttributes.Italic` on an `IFontElement` element.
+
+The following example sets the button font to italic:
+
+```csharp
+new Button().Italic()
+```
+
+## Font
+
+The `Font` method sets `FontFamily`, `FontSize`, and `FontAttributes` on an `IFontElement` element.
+
+The following example sets the button font to italic:
+
+```csharp
+new Button().Font(family: "OpenSansRegular", size: 12.5, bold: true, italic: true);
+```
+
+## TextColor
+
+The `TextColor` method sets the `TextColor` property on an `ITextStyle` element.
+
+The following example sets the `TextColor` to `Colors.Green`:
+
+```csharp
+new Button().TextColor(Colors.Green);
+```
+
+## Text
+
+The `Text` methods sets the `Text` property on an `IText` element.
+
+The following example sets the `Text` to `"Tap Here"`:
+
+```csharp
+new Button().Text("Tap Here");
+```
+
+The following example sets the `Text` to `"Tap Here"` and sets the `TextColor` property to `Colors.Blue`:
+
+```csharp
+new Button().Text("Tap Here", Colors.Blue);
+```

--- a/docs/maui/markup/extensions/element-extensions.md
+++ b/docs/maui/markup/extensions/element-extensions.md
@@ -1,5 +1,5 @@
 ---
-title: Element Extensions - .NET MAUI Community Toolkit
+title: Element extensions - .NET MAUI Community Toolkit
 author: brminnick
 description: The Element extensions provide a series of extension methods that support configuring the sizing, styling and behaviors of an Element.
 ms.date: 03/28/2022

--- a/docs/maui/markup/extensions/element-extensions.md
+++ b/docs/maui/markup/extensions/element-extensions.md
@@ -11,8 +11,6 @@ ms.date: 03/28/2022
 
 The `Element` extensions provide a series of extension methods that support configuring the padding, effects, font attributes, dynamic resources, text, and text color of an `Element`.
 
-The extensions offer the following methods:
-
 ## Padding
 
 The `Padding` method sets the `Padding` property on an `IPaddingElement`.


### PR DESCRIPTION
This PR adds documentation for CommunityToolkit.Maui.Markup's `ElementExtensions.cs`

Included is the documentation for `.Text()` and `.TextColor` extension methods added in this currently open PR on `CommunityToolkit.Maui.Markup`: https://github.com/CommunityToolkit/Maui.Markup/pull/39