### PR TITLE
Add `IPlaceholder` Extensions Docs for Maui.Markup

### DIFF
--- a/docs/maui/TOC.yml
+++ b/docs/maui/TOC.yml
@@ -71,5 +71,7 @@ items:
       href: markup/extensions/bindable-object-extensions.md
     - name: "Element extensions"
       href: markup/extensions/element-extensions.md
+    - name: "Placeholder extensions"
+      href: markup/extensions/placeholder-extensions.md
     - name: "VisualElement extensions"
       href: markup/extensions/visual-element-extensions.md

--- a/docs/maui/markup/extensions/placeholder-extensions.md
+++ b/docs/maui/markup/extensions/placeholder-extensions.md
@@ -27,12 +27,16 @@ new Entry().PlaceholderColor(Colors.Red);
 
 The `Placeholder` methods sets the `Placeholder` property on an `IPlaceholder` element.
 
-There is a second, overloaded, method for `Placeholder` that will set both the `Placeholder` and `PlaceholderColor` properties on an `IPlaceholder` element
-
-The following examples sets the `Placeholder` to `"Enter Text"` and the `PlaceholderColor` to `Colors.Grey`:
+The following example sets the `Placeholder` to `"Enter Text"`:
 
 ```csharp
-new Editor().Placeholder("Enter Text");
+new Entry().Placeholder("Enter Text");
+```
 
-new Entry().Placeholder("Enter Text", Colors.Grey);
+There is a second, overloaded, method for `Placeholder` that will set both the `Placeholder` and `PlaceholderColor` properties on an `IPlaceholder` element.
+
+The following example sets the `Placeholder` to `"Address, City, State"` and the `PlaceholderColor` to `Colors.Grey`:
+
+```csharp
+new Editor().Placeholder("Address, City, State", Colors.Grey);
 ```

--- a/docs/maui/markup/extensions/placeholder-extensions.md
+++ b/docs/maui/markup/extensions/placeholder-extensions.md
@@ -1,0 +1,38 @@
+---
+title: Placeholder extensions - .NET MAUI Community Toolkit
+author: brminnick
+description: The Placeholder extensions provide a series of extension methods that support configuring `IPlaceholder` controls
+ms.date: 03/28/2022
+---
+
+# Placeholder extensions
+
+[!INCLUDE [docs under construction](../../includes/preview-note.md)]
+
+The `Placeholder` extensions provide a series of extension methods that support support configuring `IPlaceholder` controls.
+
+The extensions offer the following methods:
+
+## PlaceholderColor
+
+The `PlaceholderColor` method sets the `PlaceholderColor` property on an `IPlaceholder` element.
+
+The following example sets the `PlaceholderColor` to `Colors.Red`:
+
+```csharp
+new Entry().PlaceholderColor(Colors.Red);
+```
+
+## Placeholder
+
+The `Placeholder` methods sets the `Placeholder` property on an `IPlaceholder` element.
+
+There is a second, overloaded, method for `Placeholder` that will set both the `Placeholder` and `PlaceholderColor` properties on an `IPlaceholder` element
+
+The following examples sets the `Placeholder` to `"Enter Text"` and the `PlaceholderColor` to `Colors.Grey`:
+
+```csharp
+new Editor().Placeholder("Enter Text");
+
+new Entry().Placeholder("Enter Text", Colors.Grey);
+```

--- a/docs/maui/markup/extensions/placeholder-extensions.md
+++ b/docs/maui/markup/extensions/placeholder-extensions.md
@@ -1,7 +1,7 @@
 ---
 title: Placeholder extensions - .NET MAUI Community Toolkit
 author: brminnick
-description: The Placeholder extensions provide a series of extension methods that support configuring `IPlaceholder` controls
+description: The Placeholder extensions provide a series of extension methods that support configuring IPlaceholder controls
 ms.date: 03/28/2022
 ---
 

--- a/docs/maui/markup/extensions/placeholder-extensions.md
+++ b/docs/maui/markup/extensions/placeholder-extensions.md
@@ -25,7 +25,7 @@ new Entry().PlaceholderColor(Colors.Red);
 
 ## Placeholder
 
-The `Placeholder` methods sets the `Placeholder` property on an `IPlaceholder` element.
+The `Placeholder` method sets the `Placeholder` property on an `IPlaceholder` element.
 
 The following example sets the `Placeholder` to `"Enter Text"`:
 


### PR DESCRIPTION
This PR adds the Maui.Markup docs for the `IPlaceholder` extension methods added in this PR: https://github.com/CommunityToolkit/Maui.Markup/pull/44/files