### PR TITLE
Add `IImage` Extensions Docs

### DIFF
--- a/docs/maui/TOC.yml
+++ b/docs/maui/TOC.yml
@@ -71,6 +71,8 @@ items:
       href: markup/extensions/bindable-object-extensions.md
     - name: "Element extensions"
       href: markup/extensions/element-extensions.md
+    - name: "Image extensions"
+      href: markup/extensions/image-extensions.md
     - name: "Placeholder extensions"
       href: markup/extensions/placeholder-extensions.md
     - name: "VisualElement extensions"

--- a/docs/maui/markup/extensions/image-extensions.md
+++ b/docs/maui/markup/extensions/image-extensions.md
@@ -27,7 +27,7 @@ new Image().Source("dotnet_bot");
 
 The `Aspect` method sets the `Aspect` property on an `IImage` element.
 
-The following example sets the `Aspect` to `"Aspect.AspectFill"`:
+The following example sets the `Aspect` to `Aspect.AspectFill`:
 
 ```csharp
 new Image().Aspect(Aspect.AspectFill);

--- a/docs/maui/markup/extensions/image-extensions.md
+++ b/docs/maui/markup/extensions/image-extensions.md
@@ -1,0 +1,44 @@
+---
+title: Image extensions - .NET MAUI Community Toolkit
+author: brminnick
+description: The Image extensions provide a series of extension methods that support configuring IImage controls
+ms.date: 03/28/2022
+---
+
+# Placeholder extensions
+
+[!INCLUDE [docs under construction](../../includes/preview-note.md)]
+
+The `Image` extensions provide a series of extension methods that support support configuring `IImage` controls.
+
+The extensions offer the following methods:
+
+## Source
+
+The `Source` method sets the `Source` property on an `IImage` element.
+
+The following example sets the `Source` to `"dotnet_bot"`:
+
+```csharp
+new Image().Source("dotnet_bot");
+```
+
+## Aspect
+
+The `Aspect` method sets the `Aspect` property on an `IImage` element.
+
+The following example sets the `Aspect` to `"Aspect.AspectFill"`:
+
+```csharp
+new Image().Aspect(Aspect.AspectFill);
+```
+
+## IsOpaque
+
+The `IsOpaque` method sets the `IsOpaque` property on an `IImage` element.
+
+The following example sets the `IsOpaque` to `true`:
+
+```csharp
+new Image().IsOpaque(true);
+```

--- a/docs/maui/markup/extensions/image-extensions.md
+++ b/docs/maui/markup/extensions/image-extensions.md
@@ -5,7 +5,7 @@ description: The Image extensions provide a series of extension methods that sup
 ms.date: 03/28/2022
 ---
 
-# Placeholder extensions
+# Image extensions
 
 [!INCLUDE [docs under construction](../../includes/preview-note.md)]
 

--- a/docs/maui/markup/extensions/image-extensions.md
+++ b/docs/maui/markup/extensions/image-extensions.md
@@ -9,7 +9,7 @@ ms.date: 03/28/2022
 
 [!INCLUDE [docs under construction](../../includes/preview-note.md)]
 
-The `Image` extensions provide a series of extension methods that support support configuring `IImage` controls.
+The `Image` extensions provide a series of extension methods that support configuring `IImage` controls.
 
 The extensions offer the following methods:
 

--- a/docs/maui/markup/extensions/placeholder-extensions.md
+++ b/docs/maui/markup/extensions/placeholder-extensions.md
@@ -9,7 +9,7 @@ ms.date: 03/28/2022
 
 [!INCLUDE [docs under construction](../../includes/preview-note.md)]
 
-The `Placeholder` extensions provide a series of extension methods that support support configuring `IPlaceholder` controls.
+The `Placeholder` extensions provide a series of extension methods that support configuring `IPlaceholder` controls.
 
 The extensions offer the following methods:
 


### PR DESCRIPTION
This PR adds the documentation for the `IImage` extensions added in this Maui.Markup PR: https://github.com/CommunityToolkit/Maui.Markup/pull/46

It also fixes a typo in `placeholder-extensions.md`.