### PR TITLE
Eventtocommandbehavior Doc Page

### DIFF
--- a/docs/maui/TOC.yml
+++ b/docs/maui/TOC.yml
@@ -21,6 +21,8 @@ items:
       href: behaviors/characters-validation-behavior.md
     - name: "EmailValidationBehavior"
       href: behaviors/email-validation-behavior.md
+    - name: "EventToCommandBehavior"
+      href: behaviors/event-to-command-behavior.md
     - name: MaskedBehavior
       href: behaviors/masked-behavior.md
     - name: "MaxLengthReachedBehavior"

--- a/docs/maui/behaviors/event-to-command-behavior.md
+++ b/docs/maui/behaviors/event-to-command-behavior.md
@@ -1,0 +1,99 @@
+---
+title: EventToCommandBehavior - .NET MAUI Community Toolkit
+author: cliffagius
+description: "The EventToCommandBehavior is a behavior that allows the user to invoke a Command through an event. It is designed to associate Commands to events exposed by controls that were not designed to support Commands. It allows you to map any arbitrary event on a control to a Command."
+ms.date: 04/23/2022
+---
+
+# EventToCommandBehavior
+
+[!INCLUDE [docs under construction](../includes/preview-note.md)]
+
+The `EventToCommandBehavior` is a `behavior` that allows the user to invoke a `Command` through an `Event`. It is designed to associate Commands to events exposed by controls that were not designed to support Commands. It allows you to map any arbitrary event on a control to a Command.
+
+When using this `behavior` with selection or tap events exposed by `ListView` an additional converter is required. This converter converts the event arguments to a command parameter which is then passed onto the Command. They are also available in the Maui Community Toolkit:
+
+* [ItemSelectedEventArgsConverter](../converters/item-selected-eventarg-converter.md)
+* [ItemTappedEventArgsConverter](../converters/item-tapped-eventargs-converter.md)
+
+## Syntax
+
+### XAML
+
+The `EventToCommandBehavior` can be used as follows in XAML:
+
+```xaml
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+             x:Class="MyLittleApp.MainPage">
+     
+            <Button.Behaviors>
+                <toolkit:EventToCommandBehavior
+                    EventName="Clicked"
+                    Command="{Binding MyCustomCommand}" />
+            </Button.Behaviors>
+</ContentPage>
+```
+
+### C#
+
+The `EventToCommandBehavior` can be used as follows in C#:
+
+```csharp
+class EventToCommandBehaviorPage : ContentPage
+{
+    public EventToCommandBehaviorPage()
+    {
+        var button = new Button();
+
+        var behavior = new EventToCommandBehavior
+        {
+            EventName = nameof(Button.Clicked),
+            Command = new MyCustomCommand()
+        };
+
+        button.Behaviors.Add(behavior);
+
+        Content = entry;
+    }
+}
+```
+
+### C# Markup
+
+Our [`CommunityToolkit.Maui.Markup`](../markup/markup.md) package provides a much more concise way to use this behavior in C#.
+
+```csharp
+using CommunityToolkit.Maui.Markup;
+
+class EventToCommandBehaviorPage : ContentPage
+{
+    public EventToCommandBehaviorPage()
+    {
+        Content = new Button()
+        .Behaviors(new EventToCommandBehavior
+        {
+            EventName = nameof(Button.Clicked),
+            Command = new MyCustomCommand()
+        });                 
+    }
+}
+```
+
+## Properties
+
+|Property  |Type  |Description  |
+|---------|---------|---------|
+| EventName | string | The name of the event that should be associated with a `Command`. |
+| Command | [ICommand](xref:System.Windows.Input.ICommand) | The `Command` that should be executed. |
+| CommandParameter | object | An optional parameter to forward to the `Command`. |
+| EventArgsConverter | [IValueConverter](xref:Xamarin.Forms.IValueConverter) | An optional `IValueConverter` that can be used to convert `EventArgs` values to values passed into the `Command`. |
+
+## Examples
+
+You can find an example of this behavior in action in the [.NET MAUI Community Toolkit Sample Application](https://github.com/CommunityToolkit/Maui/blob/main/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/EventToCommandBehaviorPage.xaml).
+
+## API
+
+You can find the source code for `EventToCommandBehavior` over on the [.NET MAUI Community Toolkit GitHub repository](https://github.com/CommunityToolkit/Maui/blob/main/src/CommunityToolkit.Maui/Behaviors/EventToCommandBehavior.shared.cs).

--- a/docs/maui/behaviors/index.md
+++ b/docs/maui/behaviors/index.md
@@ -21,6 +21,7 @@ The .NET MAUI Community Toolkit provides a collection of pre-built, reusable beh
 | --------- | ----------- |
 | [`CharactersValidationBehavior`](characters-validation-behavior.md) | The `CharactersValidationBehavior` is a `Behavior` that allows the user to validate text input depending on specified parameters. |
 | [`EmailValidationBehavior`](email-validation-behavior.md) | The `EmailValidationBehavior` is a `Behavior` that allows users to determine whether or not text input is a valid e-mail address. |
+| [`EventToCommandBehavior`](event-to-command-behavior.md) | The `EventToCommandBehavior` is a `behavior` that allows the user to invoke a `Command` through an `Event`. It is designed to associate Commands to events exposed by controls that were not designed to support Commands. It allows you to map any arbitrary event on a control to a Command. |
 | [`MaskedBehavior`](masked-behavior.md) | The `MaskedBehavior` is a `Behavior` that allows the user to define an input mask for data entry. |
 | [`MaxLengthReachedBehavior`](maximum-length-reached-behavior.md) | The `MaxLengthReachedBehavior` is a behavior that allows the user to trigger an action when a user has reached the maximum length allowed on an `InputView`. |
 | [`UserStoppedTypingBehavior`](user-stopped-typing-behavior.md) | The `UserStoppedTypingBehavior` is a `Behavior` that will trigger an action when a user has stopped data input on controls for example `Entry`, `SearchBar` and `Editor`. Examples of its usage include triggering a search when a user has stopped entering their search query. |


### PR DESCRIPTION
Added the Doc page for the Eventtocommandbehavior behavior but there will be a broken link at the top for the ItemSelectedEventArgsConverter.md page as this isn't in the docs repo yet.  Also the Properties section I have copied these from the XCT but the IValueConverter link has the Xamarin.forms Docs page as there isn't one for the MAUI version yet and no idea when the MAUI API docs will be made but it's going to be the same content.