### PR TITLE
Added doc page for the ProgressBarAnimationBehavior

### DIFF
--- a/docs/maui/TOC.yml
+++ b/docs/maui/TOC.yml
@@ -29,6 +29,8 @@ items:
       href: behaviors/maximum-length-reached-behavior.md
     - name: "NumericValidationBehavior"
       href: behaviors/numeric-validation-behavior.md
+    - name: "ProgressBarAnimationBehavior"
+      href: behaviors/progressbar-animation-behavior.md
     - name: "RequiredStringValidationBehavior"
       href: behaviors/required-string-validation-behavior.md
     - name: "TextValidationBehavior"

--- a/docs/maui/behaviors/index.md
+++ b/docs/maui/behaviors/index.md
@@ -25,6 +25,7 @@ The .NET MAUI Community Toolkit provides a collection of pre-built, reusable beh
 | [`MaskedBehavior`](masked-behavior.md) | The `MaskedBehavior` is a `Behavior` that allows the user to define an input mask for data entry. |
 | [`MaxLengthReachedBehavior`](maximum-length-reached-behavior.md) | The `MaxLengthReachedBehavior` is a behavior that allows the user to trigger an action when a user has reached the maximum length allowed on an `InputView`. |
 | [`NumericValidationBehavior`](numeric-validation-behavior.md) | The `NumericValidationBehavior` is a `Behavior` that allows the user to determine if text input is a valid numeric value. |
+| [`ProgressBarAnimationBehavior`](progressbar-animation-behavior.md) | The `ProgressBarAnimationBehavior` animates a `ProgressBar` from its current Progress value to a provided value over time. |
 | [`RequiredStringValidationBehavior`](required-string-validation-behavior.md) | The `RequiredStringValidationBehavior` is a `Behavior` that allows the user to determine if text input is equal to specific text. |
 | [`TextValidationBehavior`](text-validation-behavior.md) | The `TextValidationBehavior` is a `Behavior` that allows the user to validate a given text depending on specified parameters. |
 | [`UriValidationBehavior`](uri-validation-behavior.md) | The `UriValidationBehavior` is a `Behavior` that allows users to determine whether or not text input is a valid URI. |

--- a/docs/maui/behaviors/progressbar-animation-behavior.md
+++ b/docs/maui/behaviors/progressbar-animation-behavior.md
@@ -87,7 +87,7 @@ class ProgressBarAnimationBehaviorPage : ContentPage
 |---------|---------|---------|
 | Progress | Double  | New Progress value to animate to as a percentage with 1 being 100% so 0.75 is 75% |
 | Length | uint | Duration in miliseconds |
-| Easing | enum | `enum` that controls the `Easing`, allows you to specify a transfer function that controls how animations speed up or slow down. You can find more details on [Easing here](/xamarin/xamarin-forms/user-interface/animation/easing) |
+| Easing | enum | `enum` that controls the `Easing`, allows you to specify a transfer function that controls how animations speed up or slow down. You can find more details on [Easing here](/dotnet/maui/user-interface/animation/easing) |
 
 ## Examples
 

--- a/docs/maui/behaviors/progressbar-animation-behavior.md
+++ b/docs/maui/behaviors/progressbar-animation-behavior.md
@@ -1,0 +1,98 @@
+---
+title: ProgressBarAnimationBehavior - .NET MAUI Community Toolkit
+author: cliffagius
+description: "The ProgressBar Animation Behavior animates a ProgressBar from its current Progress value to a provided value over time."
+ms.date: 04/29/2022
+---
+
+# ProgressBarAnimationBehavior
+
+[!INCLUDE [docs under construction](../includes/preview-note.md)]
+
+The ProgressBar Animation Behavior animates a `ProgressBar` from its current Progress value to a provided value over time. The method accepts a `Double` progress value, a `uint` duration in milliseconds, an `Easing` enum value.
+
+## Syntax
+
+### XAML
+
+The `ProgressBarAnimationBehavior` can be used as follows in XAML:
+
+```xaml
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+             x:Class="MyLittleApp.MainPage">
+     
+        <Label Text="The ProgressBarAnimationBehavior is a behavior that animates a ProgressBar" />
+
+        <ProgressBar>
+            <ProgressBar.Behaviors>
+                <toolkit:ProgressBarAnimationBehavior
+                    x:Name="ProgressBarAnimationBehavior"
+                    Progress="{Binding Progress}"
+                    Length="250"/>
+            </ProgressBar.Behaviors>
+        </ProgressBar>
+</ContentPage>
+```
+
+### C#
+
+The `ProgressBarAnimationBehavior` can be used as follows in C#:
+
+```csharp
+class ProgressBarAnimationBehaviorPage : ContentPage
+{
+    public ProgressBarAnimationBehaviorPage()
+    {
+        var progressBar = new ProgressBar();
+
+        var behavior = new ProgressBarAnimationBehavior()
+        {
+            Progress = 0.75,
+            Length = 250
+        };
+
+        progressBar.Behaviors.Add(behavior);
+
+        Content = progressBar;
+    }
+}
+```
+
+### C# Markup
+
+Our [`CommunityToolkit.Maui.Markup`](../markup/markup.md) package provides a much more concise way to use this behavior in C#.
+
+```csharp
+using CommunityToolkit.Maui.Markup;
+
+class ProgressBarAnimationBehaviorPage : ContentPage
+{
+    public ProgressBarAnimationBehaviorPage()
+    {
+        Content = new ProgressBar()
+        .Behaviors(new ProgressBarAnimationBehavior
+        {
+            Progress = 0.75,
+            Length = 250
+        });           
+    }
+}
+```
+
+## Properties
+
+|Property  |Type  |Description  |
+|---------|---------|---------|
+| Progress | Double  | New Progress value to animate to. |
+| Length | uint | Duration in miliseconds |
+| Easing | enum | `enum` that controls the `Easing`, allows you to specify a transfer function that controls how animations speed up or slow down. You can find more details on [Easing here](https://docs.microsoft.com/xamarin/xamarin-forms/user-interface/animation/easing) |
+
+## Examples
+
+You can find an example of this behavior in action in the [.NET MAUI Community Toolkit Sample Application](https://github.com/CommunityToolkit/Maui/blob/main/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/ProgressBarAnimationBehaviorPage.xaml).
+
+## API
+
+You can find the source code for `ProgressBarAnimationBehavior` over on the [.NET MAUI Community Toolkit GitHub repository](https://github.com/CommunityToolkit/Maui/blob/main/src/CommunityToolkit.Maui/Behaviors/ProgressBarAnimationBehavior.shared.cs).

--- a/docs/maui/behaviors/progressbar-animation-behavior.md
+++ b/docs/maui/behaviors/progressbar-animation-behavior.md
@@ -2,14 +2,14 @@
 title: ProgressBarAnimationBehavior - .NET MAUI Community Toolkit
 author: cliffagius
 description: "The ProgressBar Animation Behavior animates a ProgressBar from its current Progress value to a provided value over time."
-ms.date: 04/29/2022
+ms.date: 05/02/2022
 ---
 
 # ProgressBarAnimationBehavior
 
 [!INCLUDE [docs under construction](../includes/preview-note.md)]
 
-The ProgressBar Animation Behavior animates a `ProgressBar` from its current Progress value to a provided value over time. The method accepts a `Double` progress value, a `uint` duration in milliseconds, an `Easing` enum value.
+The ProgressBar Animation Behavior animates a `ProgressBar` from its current Progress value to a provided value over time. The method accepts a `Double` progress value, a `uint` duration in milliseconds and an `Easing` enum value.
 
 ## Syntax
 
@@ -85,9 +85,9 @@ class ProgressBarAnimationBehaviorPage : ContentPage
 
 |Property  |Type  |Description  |
 |---------|---------|---------|
-| Progress | Double  | New Progress value to animate to. |
+| Progress | Double  | New Progress value to animate to as a percentage with 1 being 100% so 0.75 is 75% |
 | Length | uint | Duration in miliseconds |
-| Easing | enum | `enum` that controls the `Easing`, allows you to specify a transfer function that controls how animations speed up or slow down. You can find more details on [Easing here](https://docs.microsoft.com/xamarin/xamarin-forms/user-interface/animation/easing) |
+| Easing | enum | `enum` that controls the `Easing`, allows you to specify a transfer function that controls how animations speed up or slow down. You can find more details on [Easing here](/xamarin/xamarin-forms/user-interface/animation/easing) |
 
 ## Examples
 


### PR DESCRIPTION
New docs page for the ProgressBarAnimationBehavior along with the Index and TOC changes...

This will close [Proposal] ProgressBar Animation Behavior https://github.com/CommunityToolkit/Maui/issues/48

There is an issue that I can see with the docs in that for the Docs to show a working example I had to leave the Easing out as it looks like there is no bindable property. 

In the MCT sample app there is a note in the page code behind file:

https://github.com/CommunityToolkit/Maui/blob/main/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/ProgressBarAnimationBehaviorPage.xaml.cs

Not sure if we should mention this limitation in the docs or look at fixing the issue so for now I have left it out and looking for guidance.