### PR TITLE
Added the missing 'this.' prefix for popup sample

### DIFF
--- a/docs/maui/views/popup.md
+++ b/docs/maui/views/popup.md
@@ -69,7 +69,7 @@ public class MyPage : ContentPage
     {
         var popup = new SimplePopup();
 
-        ShowPopup(popup);
+        this.ShowPopup(popup);
     }
 }
 ```
@@ -155,7 +155,7 @@ public class MyPage : ContentPage
     {
         var popup = new SimplePopup();
 
-        var result = await ShowPopupAsync(popup);
+        var result = await this.ShowPopupAsync(popup);
 
         if (result is bool boolResult)
         {


### PR DESCRIPTION
Fixes #110 

The change includes `this.` otherwise the extension method is not usable.