### PR TITLE
Fix toolkit name to include .NET in the breadcrumb

### DIFF
--- a/docs/breadcrumb/toc.yml
+++ b/docs/breadcrumb/toc.yml
@@ -16,6 +16,6 @@
         - name: MVVM Toolkit
           tocHref: /dotnet/communitytoolkit/mvvm/
           topicHref: /dotnet/communitytoolkit/mvvm/index
-        - name: MAUI Community Toolkit
+        - name: .NET MAUI Community Toolkit
           tocHref: /dotnet/communitytoolkit/maui/
           topicHref: /dotnet/communitytoolkit/maui/index


### PR DESCRIPTION
Changes the breadcrumb to show `.NET MAUI` instead of just `MAUI`