### PR TITLE
CommunityToolkit.Maui.IServiceCollectionExtensions 

### DIFF
--- a/docs/maui/TOC.yml
+++ b/docs/maui/TOC.yml
@@ -157,6 +157,8 @@ items:
       href: extensions/color-animation-extensions.md
     - name: ColorConversionExtensions
       href: extensions/color-conversion-extensions.md
+    - name: ServiceCollectionExtensions
+      href: extensions/servicecollection-extensions.md
 - name: "Layouts"
   items:
     - name: "UniformItemsLayout"

--- a/docs/maui/extensions/index.md
+++ b/docs/maui/extensions/index.md
@@ -17,3 +17,4 @@ The .NET MAUI Community Toolkit provides a collection of extension methods to ma
 | --------- | ----------- |
 | [`ColorAnimationExtensions`](color-animation-extensions.md) | The `ColorAnimationExtensions` provide a series of extension methods that support animating the `Color` related properties of a `VisualElement`. |
 | [`ColorConversionExtensions`](color-conversion-extensions.md) | The `ColorConversionExtensions` provide a series of extension methods that support converting, modifying or inspecting `Color`s. |
+| [`ServiceCollectionExtensions`](servicecollection-extensions.md) | The `ServiceCollectionExtensions` provide a series of extension methods that simplify registering Views and their associated ViewModels within the .NET MAUI `IServiceCollection`. |

--- a/docs/maui/extensions/servicecollection-extensions.md
+++ b/docs/maui/extensions/servicecollection-extensions.md
@@ -17,6 +17,10 @@ The `ServiceCollectionExtensions` can be found under the `CommunityToolkit.Maui`
 using CommunityToolkit.Maui;
 ```
 
+> NOTE: These extension methods only register the View and ViewModels in the `IServiceCollection`. Developers are still responsible for assigning the injected instance of the ViewModel to the `BindingContext` property of the View.
+>
+> Additionally, these extension methods assume there is a one-to-one relationship between View and ViewModel and that both share the same lifetime. Developers will need to revert to registering Views and ViewModels individually in order to specify differing lifetimes or to handle scenarios in which multiple Views  use the same ViewModel.
+
 ## Register Views and ViewModels
 
 The following methods allow you to register Views and ViewModels within the .NET MAUI `IServiceCollection`.

--- a/docs/maui/extensions/servicecollection-extensions.md
+++ b/docs/maui/extensions/servicecollection-extensions.md
@@ -313,4 +313,4 @@ A reference to this instance after the operation has completed.
 
 ## API
 
-You can find the source code for `ServiceCollectionExtensions` over on the [.NET MAUI Community Toolkit GitHub repository](https://github.com/CommunityToolkit/Maui/blob/main/src/CommunityToolkit.Maui.Core/Extensions/ServiceCollectionExtensions.shared.cs).
+You can find the source code for `ServiceCollectionExtensions` over on the [.NET MAUI Community Toolkit GitHub repository](https://github.com/CommunityToolkit/Maui/blob/main/src/CommunityToolkit.Maui/Extensions/ServiceCollectionExtensions.shared.cs).

--- a/docs/maui/extensions/servicecollection-extensions.md
+++ b/docs/maui/extensions/servicecollection-extensions.md
@@ -5,6 +5,8 @@ description: "The ServiceCollectionExtensions provide a series of extension meth
 ms.date: 04/22/2022
 ---
 
+<!-- markdownlint-configure-file { "MD024": { "allow_different_nesting": true } } -->
+
 # ServiceCollectionExtensions
 
 The `ServiceCollectionExtensions` provide a series of extension methods that simplify registering Views and their associated ViewModels within the .NET MAUI `IServiceCollection`.

--- a/docs/maui/extensions/servicecollection-extensions.md
+++ b/docs/maui/extensions/servicecollection-extensions.md
@@ -2,7 +2,7 @@
 title: ServiceCollectionExtensions - .NET MAUI Community Toolkit
 author: rjygraham
 description: "The ServiceCollectionExtensions provide a series of extension methods that simplify registering Views and ViewModels within a .NET MAUI  IServiceCollection."
-ms.date: 04/22/2022
+ms.date: 07/19/2022
 ---
 
 <!-- markdownlint-configure-file { "MD024": { "allow_different_nesting": true } } -->

--- a/docs/maui/extensions/servicecollection-extensions.md
+++ b/docs/maui/extensions/servicecollection-extensions.md
@@ -1,0 +1,310 @@
+---
+title: ServiceCollectionExtensions - .NET MAUI Community Toolkit
+author: rjygraham
+description: "The ServiceCollectionExtensions provide a series of extension methods that simplify registering Views and ViewModels within a .NET MAUI  IServiceCollection."
+ms.date: 04/22/2022
+---
+
+# ServiceCollectionExtensions
+
+The `ServiceCollectionExtensions` provide a series of extension methods that simplify registering Views and their associated ViewModels within the .NET MAUI `IServiceCollection`.
+
+The `ServiceCollectionExtensions` can be found under the `CommunityToolkit.Maui` namespace so just add the following line to get started:
+
+```csharp
+using CommunityToolkit.Maui;
+```
+
+## Register Views and ViewModels
+
+The following methods allow you to register Views and ViewModels within the .NET MAUI `IServiceCollection`.
+
+### AddScoped<TView, TViewModel>(IServiceCollection)
+
+Adds a scoped View of the type specified in TView and ViewModel of the type TViewModel to the specified IServiceCollection.
+
+```csharp
+using CommunityToolkit.Maui;
+
+namespace CommunityToolkit.Maui.Sample;
+
+public static class MauiProgram
+{
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder()
+                            .UseMauiCommunityToolkit()
+                            .UseMauiApp<App>();
+
+        builder.Services.AddScoped<HomePage, HomePageViewModel>();
+    }
+}
+```
+
+#### Type Parameters
+
+##### TView
+
+The type of the View to add. Constrained to `BindableObject`
+
+##### TViewModel
+
+The type of the ViewModel to add. Constrained to reference types implementing `INotifyPropertyChanged`
+
+#### Parameters
+
+##### `services` [IServiceCollection](/dotnet/api/microsoft.extensions.dependencyinjection.iservicecollection)
+
+The [IServiceCollection](/dotnet/api/microsoft.extensions.dependencyinjection.iservicecollection) to add the View and ViewModel to.
+
+#### Returns
+
+[IServiceCollection](/dotnet/api/microsoft.extensions.dependencyinjection.iservicecollection)
+A reference to this instance after the operation has completed.
+
+### AddSingleton<TView, TViewModel>(IServiceCollection)
+
+Adds a singleton View of the type specified in TView and ViewModel of the type TViewModel to the specified IServiceCollection.
+
+```csharp
+using CommunityToolkit.Maui;
+
+namespace CommunityToolkit.Maui.Sample;
+
+public static class MauiProgram
+{
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder()
+                            .UseMauiCommunityToolkit()
+                            .UseMauiApp<App>();
+
+        builder.Services.AddSingleton<HomePage, HomePageViewModel>();
+    }
+}
+```
+
+#### Type Parameters
+
+##### TView
+
+The type of the View to add. Constrained to `BindableObject`
+
+##### TViewModel
+
+The type of the ViewModel to add. Constrained to reference types implementing `INotifyPropertyChanged`
+
+#### Parameters
+
+##### `services` [IServiceCollection](/dotnet/api/microsoft.extensions.dependencyinjection.iservicecollection)
+
+The [IServiceCollection](/dotnet/api/microsoft.extensions.dependencyinjection.iservicecollection) to add the View and ViewModel to.
+
+#### Returns
+
+[IServiceCollection](/dotnet/api/microsoft.extensions.dependencyinjection.iservicecollection)
+A reference to this instance after the operation has completed.
+
+### AddTransient<TView, TViewModel>(IServiceCollection)
+
+Adds a transient View of the type specified in TView and ViewModel of the type TViewModel to the specified IServiceCollection.
+
+```csharp
+using CommunityToolkit.Maui;
+
+namespace CommunityToolkit.Maui.Sample;
+
+public static class MauiProgram
+{
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder()
+                            .UseMauiCommunityToolkit()
+                            .UseMauiApp<App>();
+
+        builder.Services.AddTransient<HomePage, HomePageViewModel>();
+    }
+}
+```
+
+#### Type Parameters
+
+##### TView
+
+The type of the View to add. Constrained to `BindableObject`
+
+##### TViewModel
+
+The type of the ViewModel to add. Constrained to reference types implementing `INotifyPropertyChanged`
+
+#### Parameters
+
+##### `services` [IServiceCollection](/dotnet/api/microsoft.extensions.dependencyinjection.iservicecollection)
+
+The [IServiceCollection](/dotnet/api/microsoft.extensions.dependencyinjection.iservicecollection) to add the View and ViewModel to.
+
+#### Returns
+
+[IServiceCollection](/dotnet/api/microsoft.extensions.dependencyinjection.iservicecollection)
+A reference to this instance after the operation has completed.
+
+## Register Views and ViewModels With Shell Route
+
+The following methods allow you to register Views and ViewModels within the .NET MAUI `IServiceCollection` and explicitly register a route to the View within .NET MAUI Shell routing.
+
+### AddScopedWithShellRoute<TView, TViewModel>(services, route, factory)
+
+Adds a scoped View of the type specified in TView and ViewModel of the type TViewModel to the specified IServiceCollection and registers the view for Shell navigation at the route specified in the route parameter. An optional `RouteFactory` can be provided to control View construction.
+
+```csharp
+using CommunityToolkit.Maui;
+
+namespace CommunityToolkit.Maui.Sample;
+
+public static class MauiProgram
+{
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder()
+                            .UseMauiCommunityToolkit()
+                            .UseMauiApp<App>();
+
+        builder.Services.AddScopedWithShellRoute<HomePage, HomePageViewModel>("HomePage");
+    }
+}
+```
+
+#### Type Parameters
+
+##### TView
+
+The type of the View to add. Constrained to `NavigableElement`
+
+##### TViewModel
+
+The type of the ViewModel to add. Constrained to reference types implementing `INotifyPropertyChanged`
+
+#### Parameters
+
+##### `services` [IServiceCollection](/dotnet/api/microsoft.extensions.dependencyinjection.iservicecollection)
+
+The [IServiceCollection](/dotnet/api/microsoft.extensions.dependencyinjection.iservicecollection) to add the View and ViewModel to.
+
+##### `route` [string](/dotnet/api/system.string)
+
+The route to which the View can be navigated within .NET MAUI Shell.
+
+##### `factory (optional)` `RouteFactory`
+
+The `RouteFactory` to control View construction.
+
+#### Returns
+
+[IServiceCollection](/dotnet/api/microsoft.extensions.dependencyinjection.iservicecollection)
+A reference to this instance after the operation has completed.
+
+### AddSingletonWithShellRoute<TView, TViewModel>(services, route, factory)
+
+Adds a singleton View of the type specified in TView and ViewModel of the type TViewModel to the specified IServiceCollection and registers the view for Shell navigation at the route specified in the route parameter. An optional `RouteFactory` can be provided to control View construction.
+
+```csharp
+using CommunityToolkit.Maui;
+
+namespace CommunityToolkit.Maui.Sample;
+
+public static class MauiProgram
+{
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder()
+                            .UseMauiCommunityToolkit()
+                            .UseMauiApp<App>();
+
+        builder.Services.AddSingletonWithShellRoute<HomePage, HomePageViewModel>("HomePage");
+    }
+}
+```
+
+#### Type Parameters
+
+##### TView
+
+The type of the View to add. Constrained to `NavigableElement`
+
+##### TViewModel
+
+The type of the ViewModel to add. Constrained to reference types implementing `INotifyPropertyChanged`
+
+#### Parameters
+
+##### `services` [IServiceCollection](/dotnet/api/microsoft.extensions.dependencyinjection.iservicecollection)
+
+The [IServiceCollection](/dotnet/api/microsoft.extensions.dependencyinjection.iservicecollection) to add the View and ViewModel to.
+
+##### `route` [string](/dotnet/api/system.string)
+
+The route to which the View can be navigated within .NET MAUI Shell.
+
+##### `factory (optional)` `RouteFactory`
+
+The `RouteFactory` to control View construction.
+
+#### Returns
+
+[IServiceCollection](/dotnet/api/microsoft.extensions.dependencyinjection.iservicecollection)
+A reference to this instance after the operation has completed.
+
+### AddTransientWithShellRoute<TView, TViewModel>(services, route, factory)
+
+Adds a transient View of the type specified in TView and ViewModel of the type TViewModel to the specified IServiceCollection and registers the view for Shell navigation at the route specified in the route parameter. An optional `RouteFactory` can be provided to control View construction.
+
+```csharp
+using CommunityToolkit.Maui;
+
+namespace CommunityToolkit.Maui.Sample;
+
+public static class MauiProgram
+{
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder()
+                            .UseMauiCommunityToolkit()
+                            .UseMauiApp<App>();
+
+        builder.Services.AddTransientWithShellRoute<HomePage, HomePageViewModel>("HomePage");
+    }
+}
+```
+
+#### Type Parameters
+
+##### TView
+
+The type of the View to add. Constrained to `NavigableElement`
+
+##### TViewModel
+
+The type of the ViewModel to add. Constrained to reference types implementing `INotifyPropertyChanged`
+
+#### Parameters
+
+##### `services` [IServiceCollection](/dotnet/api/microsoft.extensions.dependencyinjection.iservicecollection)
+
+The [IServiceCollection](/dotnet/api/microsoft.extensions.dependencyinjection.iservicecollection) to add the View and ViewModel to.
+
+##### `route` [string](/dotnet/api/system.string)
+
+The route to which the View can be navigated within .NET MAUI Shell.
+
+##### `factory (optional)` `RouteFactory`
+
+The `RouteFactory` to control View construction.
+
+#### Returns
+
+[IServiceCollection](/dotnet/api/microsoft.extensions.dependencyinjection.iservicecollection)
+A reference to this instance after the operation has completed.
+
+## API
+
+You can find the source code for `ServiceCollectionExtensions` over on the [.NET MAUI Community Toolkit GitHub repository](https://github.com/CommunityToolkit/Maui/blob/main/src/CommunityToolkit.Maui.Core/Extensions/ServiceCollectionExtensions.shared.cs).


### PR DESCRIPTION
Documentation for CommunityToolkit.Maui.IServiceCollectionExtensions in PR [#494](https://github.com/CommunityToolkit/Maui/pull/494)

- Updated TOC
- Updated /extensions/index.md
- Added new ServiceCollectionExtensions page

NOTE: Markdownlint rule MD024 was set to allow_different_nesting = true at the page level due to multiple extension methods requiring documentation for parameters of same name, type, etc.
