### PR TITLE
Minor list formatting issue

### DIFF
--- a/docs/mvvm/generators/INotifyPropertyChanged.md
+++ b/docs/mvvm/generators/INotifyPropertyChanged.md
@@ -31,6 +31,7 @@ public partial class MyViewModel : SomeOtherType
 ```
 
 This will generate a complete `INotifyPropertyChanged` implementation into the `MyViewModel` type, complete with additional helpers (such as `SetProperty`) that can be used to reduce verbosity. Here is a brief summary of the various attributes:
+
 - [`INotifyPropertyChanged`](/dotnet/api/communitytoolkit.mvvm.componentmodel.INotifyPropertyChangedAttribute): implements the interface and adds helper methods to set properties and raise the events.
 - [`ObservableObject`](/dotnet/api/communitytoolkit.mvvm.componentmodel.ObservableObjectAttribute): adds all the code from the `ObservableObject` type. It is conceptually equivalent to `INotifyPropertyChanged`, with the main difference being that it also implements `INotifyPropertyChanging`.
 - [`ObservableRecipient`](/dotnet/api/communitytoolkit.mvvm.componentmodel.ObservableRecipientdAttribute): adds all the code from the `ObservableRecipient` type. In particular, this can be added to a type inheriting from `ObservableValidator` to combine the two.


### PR DESCRIPTION
The sample app does not render the list "brief summary of the various attributes" without this whitespace before the start of the list.
![image](https://user-images.githubusercontent.com/3463496/185475099-e5d82ab6-8cc6-4ad3-927a-21eb4bc8c9ab.png)
