### PR TITLE
Docs: Change example NotifyCanExecuteChangedFor argument

### DIFF
--- a/docs/mvvm/generators/RelayCommand.md
+++ b/docs/mvvm/generators/RelayCommand.md
@@ -128,7 +128,7 @@ For instance, this is how a command can be bound to a property to control its st
 
 ```csharp
 [ObservableProperty]
-[NotifyCanExecuteChangedFor(nameof(SelectedUser))]
+[NotifyCanExecuteChangedFor(nameof(GreetUserCommand))]
 private User? selectedUser;
 ```
 ```xml


### PR DESCRIPTION
From my understanding the argument of `NotifyCanExecuteChangedFor` has to be the command.