### PR TITLE
[BULK UPDATE] DocuTune - Rebranding links

### DIFF
--- a/contributing/contributing-maui.md
+++ b/contributing/contributing-maui.md
@@ -39,7 +39,7 @@ This should be simpler than adding a new file:
 
 - Links to Microsoft documentation pages should not include locale information and they should be relative. For example:
 
-  `https://docs.microsoft.com/en-us/dotnet/maui/`
+  `https://learn.microsoft.com/dotnet/maui/`
 
 should be shortened to:
 

--- a/docs/maui/markup/extensions/label-extensions.md
+++ b/docs/maui/markup/extensions/label-extensions.md
@@ -19,6 +19,6 @@ The following example demonstrates how to add multiple `Span`s to a `Label` usin
 new Label().FormattedText(new[] 
 {
     new Span { Text = "Here is a link to the docs: " },
-    new Span { Text = "https://docs.microsoft.com/", TextDecorations = TextDecorations.Underline, TextColor = Colors.Blue }
+    new Span { Text = "https://learn.microsoft.com/", TextDecorations = TextDecorations.Underline, TextColor = Colors.Blue }
 });
 ```


### PR DESCRIPTION
**Global effort for the Microsoft Learn platform rebrand**

The Microsoft team is applying changes to content for the Microsoft Learn platform rebrand. Changes include modifications to current Microsoft Learn and Microsoft Docs terminology as well as associated domain name and content URL path changes.

**DO NOT MERGE THIS PULL REQUEST WHILE IN DRAFT STATUS!** Some of the changes to links and other content are not valid until after go-live.

Please review this draft PR and provide any necessary comments as soon as possible. Because these fixes are tightly scoped, we have approval to automatically merge these changes to the default branch for publication.

This PR was generated via DocuTune. It includes only targeted fixes and minor formatting adjustments.

CorrelationId: d8c4c3ac-d49a-4c95-9ddc-9822ca297907
InitiativeId: docutune-rebranding-2022-09
PointOfContact: Alex Buck
