### PR TITLE
Add Tizen support on docs

### DIFF
--- a/docs/maui/alerts/toast.md
+++ b/docs/maui/alerts/toast.md
@@ -72,3 +72,4 @@ You can find the source code for `Toast` over on the [.NET MAUI Community Toolki
 
 1. The API allows override existing methods with your own implementation or creating your own Toast, by implementing `IToast` interface.
 2. Toast is implemented on Android, created by Google. Other platforms use a custom-implemented container (`UIView` for iOS and MacCatalyst, `ToastNotification` on Windows).
+3. Toast on Tizen can't be customized with its `Duration` and `TextSize` properties.

--- a/docs/maui/index.md
+++ b/docs/maui/index.md
@@ -25,10 +25,7 @@ The .NET MAUI Community Toolkit supports the platforms officially supported by [
 * iOS 10 or higher.
 * macOS 10.15 or higher, using Mac Catalyst.
 * Windows 11 and Windows 10 version 1809 or higher, using [Windows UI Library (WinUI) 3](/windows/apps/winui/winui3/).
-
-## Additional platform support
-
-.NET MAUI Community Toolkit also includes Tizen support, which is provided by Samsung.
+* Tizen 7.0 or higher.
 
 ## [Get started][get-started]
 

--- a/docs/maui/index.md
+++ b/docs/maui/index.md
@@ -26,8 +26,9 @@ The .NET MAUI Community Toolkit supports the platforms officially supported by [
 * macOS 10.15 or higher, using Mac Catalyst.
 * Windows 11 and Windows 10 version 1809 or higher, using [Windows UI Library (WinUI) 3](/windows/apps/winui/winui3/).
 
-> [!NOTE]
-> While there is support for Tizen (provided by Samsung) in .NET MAUI, the .NET MAUI Community Toolkit does not currently support it.
+## Additional platform support
+
+.NET MAUI Community Toolkit also includes Tizen support, which is provided by Samsung.
 
 ## [Get started][get-started]
 


### PR DESCRIPTION

This PR updates the additional platform support on the CommunityToolkit and the content links to the .NET MAUI supported versions page.
Tizen support PR https://github.com/CommunityToolkit/Maui/pull/692/ is planned to be merged and released likely on 08 November.

