### PR TITLE
[Maui.Markup] Add `ObjectExtension` Docs

### DIFF
--- a/docs/maui/TOC.yml
+++ b/docs/maui/TOC.yml
@@ -219,6 +219,8 @@ items:
       href: markup/extensions/itemsview-extensions.md
     - name: "Label extensions"
       href: markup/extensions/label-extensions.md
+    - name: "Object extensions"
+      href: markup/extensions/object-extensions.md
     - name: "Placeholder extensions"
       href: markup/extensions/placeholder-extensions.md
     - name: "Style<T>"

--- a/docs/maui/behaviors/email-validation-behavior.md
+++ b/docs/maui/behaviors/email-validation-behavior.md
@@ -9,6 +9,10 @@ ms.date: 04/20/2022
 
 The `EmailValidationBehavior` is a `Behavior` that allows users to determine whether or not text input is a valid e-mail address. For example, an `Entry` control can be styled differently depending on whether a valid or an invalid e-mail address is provided. The validation is achieved through a regular expression that is used to verify whether or not the text input is a valid e-mail address.
 
+When attached to an `InputView` (e.g. `Entry`, `Editor`, etc.), `EmailValidationBehavior` will change the default Keyboard, `Keyboard.Default`, to `Keyboard.Email`. If a non-default `Keyboard` has been specified for the `InputView`, `EmailValidationBehavior` will not change the `Keyboard`.
+
+When detached from an `InputView`, `EmailValidationBehavior` will change `Keyboard.Email` back to `Keyboard.Default`. If a `Keyboard` other than `Keyboard.Email` has been specified for the `InputView`, `EmailValidationBehavior`, will not change the `Keyboard` when detaching.
+
 ## Syntax
 
 The following examples show how to add the `EmailValidationBehavior` to an `Entry` and change the `TextColor` based on whether the entered text is a valid email address.

--- a/docs/maui/markup/extensions/bindable-object-extensions.md
+++ b/docs/maui/markup/extensions/bindable-object-extensions.md
@@ -98,33 +98,6 @@ new Button()
         nameof(ViewModel.SubmitCommand));
 ```
 
-## Assign
-
-The `Assign` method makes it possible to refer to the `BindableObject` being fluently built within the calls. This is extremely useful for setting up a `RelativeSource` to `Self` binding.
-
-This example binds the `TextColor` of the `Label` to inverse of it's `BackgroundColor`:
-
-```csharp
-Content = new Label()
-    .Assign(out var self)
-    .Bind(
-        Label.TextColorProperty,
-        path: nameof(Label.BackgroundColor),
-        source: self,
-        converter: new ColorToInverseColorConverter());
-```
-
-## Invoke
-
-The `Invoke` method allows you to perform an action against the `BindableObject`. This effectively allows you to fluently hook up event handlers or configure other parts of your application.
-
-This example hooks up to the `SelectionChanged` event on the `CollectionView`.
-
-```csharp
-new CollectionView()
-    .Invoke(collectionView => collectionView.SelectionChanged += HandleSelectionChanged);
-```
-
 ## AppThemeBinding
 
 The `AppThemeBinding` method allows for a light and dark value to assigned to a `BindableProperty` so that when the applications `AppTheme` is modified the appropriate value will be used for that theme.

--- a/docs/maui/markup/extensions/object-extensions.md
+++ b/docs/maui/markup/extensions/object-extensions.md
@@ -15,7 +15,7 @@ The extensions offer the following methods:
 
 The `Assign` method makes it possible to assign a variable fluently. This is extremely useful for setting up a view-to-view binding.
 
-This example binds the `TextColor` of the `Label` to inverse of it's `BackgroundColor`:
+This example binds the `TextColor` of the `Label` to be the inverse of its `BackgroundColor`:
 
 ```csharp
 Content = new Label()

--- a/docs/maui/markup/extensions/object-extensions.md
+++ b/docs/maui/markup/extensions/object-extensions.md
@@ -1,0 +1,41 @@
+---
+title: Object extensions - .NET MAUI Community Toolkit
+author: brminnick
+description: The Object Extensions provide a series of extension methods that support configuring any object.
+ms.date: 11/05/2022
+---
+
+# Object extensions
+
+The `Object` extensions provide a series of extension methods that support configuring any C# object (including reference types, value types, records, structs, etc).
+
+The extensions offer the following methods:
+
+## Assign
+
+The `Assign` method makes it possible to assign a variable fluently. This is extremely useful for setting up a view-to-view binding.
+
+This example binds the `TextColor` of the `Label` to inverse of it's `BackgroundColor`:
+
+```csharp
+Content = new Label()
+    .Assign(out var label)
+    .Bind(
+        Label.TextColorProperty,
+        path: nameof(Label.BackgroundColor),
+        source: label,
+        converter: new ColorToInverseColorConverter());
+```
+
+## Invoke
+
+The `Invoke` method allows you to perform an `Action` against. 
+
+One benefit is the ability to fluently subscribe event handlers or configure other parts of your application.
+
+This example subscribes the `SelectionChanged` event on the `CollectionView`.
+
+```csharp
+new CollectionView()
+    .Invoke(collectionView => collectionView.SelectionChanged += HandleSelectionChanged);
+```


### PR DESCRIPTION
This PR adds docs for the newly created `ObjectExtends.cs` class introduced in this PR: https://github.com/CommunityToolkit/Maui.Markup/pull/131

**Note:** This PR will be merged upon release of `CommunityToolkit.Maui.Markup v1.3.0`