### PR TITLE
Include section on generic type for event args

### DIFF
--- a/docs/maui/behaviors/event-to-command-behavior.md
+++ b/docs/maui/behaviors/event-to-command-behavior.md
@@ -9,12 +9,9 @@ ms.date: 04/23/2022
 
 The `EventToCommandBehavior` is a `behavior` that allows the user to invoke a `Command` through an `Event`. It is designed to associate Commands to events exposed by controls that were not designed to support Commands. It allows you to map any arbitrary event on a control to a Command.
 
-When using this `behavior` with selection or tap events exposed by `ListView` an additional converter is required. This converter converts the event arguments to a command parameter which is then passed onto the Command. They are also available in the Maui Community Toolkit:
-
-* [ItemTappedEventArgsConverter](../converters/item-tapped-eventargs-converter.md)
-* [SelectedItemEventArgsConverter](../converters/selected-item-eventargs-converter.md)
-
 ## Syntax
+
+The following examples show how to add an `EventToCommandBehavior` to a `Button` control and then handle the clicked event.
 
 ### XAML
 
@@ -81,6 +78,35 @@ class EventToCommandBehaviorPage : ContentPage
 }
 ```
 
+## Accessing the EventArgs from the event
+
+It is possible to have the `EventArgs` of the specific event passed into the `Command`. There are two ways to achieve this:
+
+### 1. Use the generic implementation
+
+By using the `EventToCommandBehavior<T>` implementation the `EventArgs` will be passed into the `Command` property if both the `CommandParameter` and `Converter` properties are not set. In order to refer to the [generic type](/dotnet/maui/xaml/generics) in XAML we need to make use of the `x:TypeArguments` directive.
+
+The following example shows how to use the generic implementation to pass the `WebNavigatedEventArgs` into the command.
+
+```xaml
+<WebView Source="https://github.com">
+    <WebView.Behaviors>
+        <toolkit:EventToCommandBehavior
+            x:TypeArguments="WebNavigatedEventArgs"
+            EventName="Navigated"
+            Command="{Binding WebViewNavigatedCommand}" />
+    </WebView.Behaviors>
+</WebView>
+```
+
+
+### 2. Use the Converter property
+
+When using this `behavior` with selection or tap events exposed by `ListView` an additional converter is required. This converter converts the event arguments to a command parameter which is then passed onto the Command. They are also available in the .NET MAUI Community Toolkit:
+
+* [ItemTappedEventArgsConverter](../converters/item-tapped-eventargs-converter.md)
+* [SelectedItemEventArgsConverter](../converters/selected-item-eventargs-converter.md)
+
 ## Properties
 
 |Property  |Type  |Description  |
@@ -88,7 +114,7 @@ class EventToCommandBehaviorPage : ContentPage
 | EventName | string | The name of the event that should be associated with a `Command`. |
 | Command | [ICommand](xref:System.Windows.Input.ICommand) | The `Command` that should be executed. |
 | CommandParameter | object | An optional parameter to forward to the `Command`. |
-| EventArgsConverter | IValueConverter | An optional `IValueConverter` that can be used to convert `EventArgs` values to values passed into the `Command`. This must be specified for `EventArgs` to be passed into the `Command`. |
+| EventArgsConverter | IValueConverter | An optional `IValueConverter` that can be used to convert `EventArgs` values to values passed into the `Command`. |
 
 ## Examples
 

--- a/docs/maui/behaviors/event-to-command-behavior.md
+++ b/docs/maui/behaviors/event-to-command-behavior.md
@@ -102,7 +102,7 @@ The following example shows how to use the generic implementation to pass the `W
 
 ### 2. Use the Converter property
 
-When using this `behavior` with selection or tap events exposed by `ListView` an additional converter is required. This converter converts the event arguments to a command parameter which is then passed onto the Command. They are also available in the .NET MAUI Community Toolkit:
+When using this `behavior` with selection or tap events exposed by `ListView` an additional converter is required. This converter converts the event arguments to a command parameter which is then passed onto the `Command`. They are also available in the .NET MAUI Community Toolkit:
 
 * [ItemTappedEventArgsConverter](../converters/item-tapped-eventargs-converter.md)
 * [SelectedItemEventArgsConverter](../converters/selected-item-eventargs-converter.md)


### PR DESCRIPTION
Improves the details of grabbing the event args through the `EventToCommandBehavior` class as previously discussed at https://github.com/CommunityToolkit/Maui/issues/569