### PR TITLE
Added a warning on the method usage.

### DIFF
--- a/docs/maui/behaviors/statusbar-behavior.md
+++ b/docs/maui/behaviors/statusbar-behavior.md
@@ -60,6 +60,11 @@ class MyPage : ContentPage
 }
 ```
 
+> [!WARNING]
+> If you want to add this code the `MainPage`'s `ctor, OnAppearing or OnNavigatedTo` methods, use the `Behavior` instead.
+> Using directly on these places can crash your application since the platform-specific components may not be initialized.
+
+
 ## Configuration
 
 # [Android](#tab/android)

--- a/docs/maui/behaviors/statusbar-behavior.md
+++ b/docs/maui/behaviors/statusbar-behavior.md
@@ -61,9 +61,8 @@ class MyPage : ContentPage
 ```
 
 > [!WARNING]
-> If you want to add this code the `MainPage`'s `ctor, OnAppearing or OnNavigatedTo` methods, use the `Behavior` instead.
+> If you want to add this code the `MainPage`'s constructor, `OnAppearing` or `OnNavigatedTo` methods, please use the `Behavior` instead.
 > Using directly on these places can crash your application since the platform-specific components may not be initialized.
-
 
 ## Configuration
 


### PR DESCRIPTION
This PR adds an info to devs where they should pay attention when changing the StatusBarColor or Style using the methods on `MCT.Core`.

This can be removed in the future, when we implement a way to queue the calls until everything is properly initialized on .NET MAUI.