### PR TITLE
Fix newline on DrawingView

### DIFF
--- a/docs/maui/views/DrawingView.md
+++ b/docs/maui/views/DrawingView.md
@@ -37,6 +37,7 @@ var drawingView = new DrawingView
 ```
 
 The following screenshot shows the resulting DrawingView on Android:
+
 ![Screenshot of an DrawingView on Android](../images/views/drawingview-android.gif "DrawingView on Android")
 
 ## MultiLine usage
@@ -67,6 +68,7 @@ var drawingView = new DrawingView
 ```
 
 The following screenshot shows the resulting DrawingView on Android:
+
 ![Screenshot of an DrawingView with multi-line on Android](../images/views/drawingview-multiline-android.gif "DrawingView on Android")
 
 ## Handle event when DrawingLineCompleted


### PR DESCRIPTION
Probably due to the length of an image, newline is required when it is seen in the wide screen.

<image src="https://user-images.githubusercontent.com/14328614/203749653-3b153030-5364-4c46-a89a-6c4e8bc9a58b.png" width="600" />
