### PR TITLE
Fix paths of .NET Community Toolkit index files

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -21,9 +21,9 @@ landingContent:
           - text: Introduction to the MVVM Toolkit
             url: mvvm/index.md
           - text: Introduction to the Diagnostics Package
-            url: /diagnostics/Introduction.md
+            url: diagnostics/Introduction.md
           - text: Introduction to the High Performance Package
-            url: /high-performance/Introduction.md
+            url: high-performance/Introduction.md
       - linkListType: get-started
         links:
           - text: Installation


### PR DESCRIPTION
This PR removes the accidental leading `/` characters, which are breaking navigation.