### PR TITLE
Add TwoWay Bindings, Use BindingMode.OneTime for ICommand

### DIFF
--- a/docs/maui/behaviors/user-stopped-typing-behavior.md
+++ b/docs/maui/behaviors/user-stopped-typing-behavior.md
@@ -85,7 +85,8 @@ class UserStoppedTypingBehaviorPage : ContentPage
         }
         .Bind(
             UserStoppedTypingBehavior.CommandProperty, 
-            static (ViewModel vm) => vm.SearchCommand));
+            static (ViewModel vm) => vm.SearchCommand),
+            mode: BindingMode.OneTime);
     }
 }
 ```

--- a/docs/maui/converters/item-tapped-eventargs-converter.md
+++ b/docs/maui/converters/item-tapped-eventargs-converter.md
@@ -114,7 +114,8 @@ class ItemTappedEventArgsConverterPage : ContentPage
             }
             .Bind(
                 EventToCommandBehavior.CommandProperty, 
-                static (ViewModel vm) => vm.ItemTappedCommand));
+                static (ViewModel vm) => vm.ItemTappedCommand,
+                mode: BindingMode.OneTime));
     }
 }
 ```

--- a/docs/maui/layouts/StateContainer.md
+++ b/docs/maui/layouts/StateContainer.md
@@ -72,13 +72,16 @@ Content = new VerticalStackLayout()
         .Text("Change State")
         .Bind(
             Button.CommandProperty,
-            static (StateContainerViewModel vm) => vm.ChangeStateCommand)
+            static (StateContainerViewModel vm) => vm.ChangeStateCommand,
+            mode: BindingMode.OneTime)
 }.Bind(
     StateContainer.CurrentStateProperty,
-    static (StateContainerViewModel vm) => vm.CurrentState)
+    static (StateContainerViewModel vm) => vm.CurrentState,
+    static (StateContainerViewModel vm, string currentState) => vm.CurrentState = currentState)
  .Bind(
     StateContainer.CanStateChange,
-    static (StateContainerViewModel vm) => vm.CanStateChange)
+    static (StateContainerViewModel vm) => vm.CanStateChange,
+    static (StateContainerViewModel vm, bool canStateChange) => vm.CanStateChange = canStateChange)
  .Assign(out VerticalStackLayout layout);
 
 var stateViews = new List<View>()

--- a/docs/maui/markup/extensions/bindable-layout-extensions.md
+++ b/docs/maui/markup/extensions/bindable-layout-extensions.md
@@ -42,7 +42,7 @@ The `ItemsSource` method sets the `ItemsSource` property on an `ILayout`.
 The following example sets the `EmptyView` to `new Label().Bind(Label.TextProperty, "."))`:
 
 ```csharp
-new VerticalStackLayout().ItemsSource(new Label().Bind(Label.TextProperty, "."));
+new VerticalStackLayout().ItemsSource(new Label().Bind(Label.TextProperty, Binding.SelfPath));
 ```
 
 ## ItemTemplate
@@ -52,13 +52,13 @@ The `ItemTemplate` method sets the `ItemTemplate` property on an `ILayout`.
 The following example sets the `EmptyViewTemplate` to `new DataTemplate(() => new Label().Bind(Label.TextProperty, ".")`:
 
 ```csharp
-new VerticalStackLayout().ItemTemplate(new DataTemplate(() => new Label().Bind(Label.TextProperty, ".")));
+new VerticalStackLayout().ItemTemplate(new DataTemplate(() => new Label().Bind(Label.TextProperty, Binding.SelfPath)));
 ```
 
 An overload method exists for `ItemTemplate` that accepts a `Func<object>` that is used to initialize the `DataTemplate`.
 
 ```csharp
-new VerticalStackLayout().ItemTemplate(() => new Label().Bind(Label.TextProperty, "."));
+new VerticalStackLayout().ItemTemplate(() => new Label().Bind(Label.TextProperty, Binding.SelfPath));
 ```
 
 ## ItemTemplateSelector

--- a/docs/maui/markup/extensions/bindable-object-extensions.md
+++ b/docs/maui/markup/extensions/bindable-object-extensions.md
@@ -21,14 +21,11 @@ There are a number of overloads for the `Bind` method.
 
 #### One way binding
 
-A one way binding from a view model (`RegistrationViewModel`) property called `RegistrationCode` to the `Text` property of an `Entry` can be created as follows:
+A one way binding from a view model (`RegistrationViewModel`) property called `RegistrationCode` to the `Text` property of an `Label` can be created as follows:
 
 ```csharp
-new Entry().Bind(Entry.TextProperty, static (RegistrationViewModel vm) => vm.RegistrationCode)
+new Entry().Bind(Label.TextProperty, static (RegistrationViewModel vm) => vm.RegistrationCode)
 ```
-
-> [!NOTE]
-> This will only result in the `RegistrationCode` property being updated when the `Text` property of the `Entry` changes (basically whenever the user types something in the box). It will **not** update the other way (e.g. changing the `RegistrationCode` property in the view model will not update the `Text` property.). To achieve this a Two way binding is required.
 
 #### Two way binding
 
@@ -117,7 +114,8 @@ The above could also be written as:
 new Button()
     .Bind(
         Entry.CommandProperty,
-        static (RegistrationViewModel vm) => vm.SubmitCommand);
+        static (RegistrationViewModel vm) => vm.SubmitCommand,
+        mode: BindingMode.OneTime);
 ```
 
 ## AppThemeBinding

--- a/docs/maui/markup/extensions/itemsview-extensions.md
+++ b/docs/maui/markup/extensions/itemsview-extensions.md
@@ -116,7 +116,7 @@ The `ItemTemplate` method sets the `ItemTemplate` property on an `ItemsView` ele
 The following example sets the `ItemTemplate` to a new `DataTemplate` containing a `Label` whose `TextProperty` is bound to the ItemsSource:
 
 ```csharp
-new CollectionView().ItemTemplate(new DataTemplate(() => new Label().Bind(Label.TextProperty, ".")));
+new CollectionView().ItemTemplate(new DataTemplate(() => new Label().Bind(Label.TextProperty, Binding.SelfPath)));
 ```
 
 ## ItemsUpdatingScrollMode

--- a/docs/maui/markup/markup.md
+++ b/docs/maui/markup/markup.md
@@ -35,7 +35,7 @@ entry.SetBinding(Entry.TextProperty, new Binding(nameof(ViewModel.RegistrationCo
 Markup allows us to define the binding fluently and therefore chain multiple methods together to reduce the verbosity of our code:
 
 ```csharp
-new Entry().Bind(Entry.TextProperty, static (ViewModel vm) => vm.RegistrationCode)
+new Entry().Bind(Entry.TextProperty, static (ViewModel vm) => vm.RegistrationCode, static (ViewModel vm, string text) => vm.RegistrationCode = text)
 ```
 
 For further details on the possible options for the `Bind` method refer to the [`BindableObject` extensions documentation](extensions/bindable-object-extensions.md).
@@ -91,14 +91,14 @@ class SampleContentPage : ContentPage
                 new Entry
                 {
                     Keyboard = Keyboard.Numeric,
-                    BackgroundColor = Colors.AliceBlue,
                 }.Row(Row.TextEntry).Column(Column.Input)
+                 .BackgroundColor(Colors.AliceBlue)
                  .FontSize(15)
                  .Placeholder("Enter number")
                  .TextColor(Colors.Black)
                  .Height(44)
                  .Margin(5, 5)
-                 .Bind(Entry.TextProperty, static (ViewModel vm) => vm.RegistrationCode)
+                 .Bind(Entry.TextProperty, static (ViewModel vm) => vm.RegistrationCode, static (ViewModel vm, string text) => vm.RegistrationCode = text)
             }
         };
     }


### PR DESCRIPTION
Hey @bijington! I updated the new binding docs a bit, adding two way bindings, where necessary, in our examples.

I also added `mode: BindingMode.OneTime` when binding to `ICommand`. It gives a small performance bump since `ICommand`s are usually read-only properties in 99.9% of apps and thus bindings to `ICommand` never change.

I also changed our one-way binding example to use `Label.TextProperty` instead of `Entry.TextProperty`. I think using `Label.TextProperty`, which defaults to a `BindingMode.OneWay` already helps simplify the example and may be more intuitive to a new dev.

