### PR TITLE
Add .NET MAUI Map for Windows docs

### DIFF
--- a/docs/maui/get-started.md
+++ b/docs/maui/get-started.md
@@ -75,6 +75,35 @@ builder
 
 To use the features of the toolkit please refer to the documentation pages for each specific feature.
 
+### [CommunityToolkit.Maui.Maps](#tab/CommunityToolkitMauiMaps)
+
+This package enables you to display a map in your .NET MAUI Windows application.
+
+**Package name:** `CommunityToolkit.Maui.Maps`
+
+**Package url:** https://www.nuget.org/packages/CommunityToolkit.Maui.Maps
+
+#### Initializing the package
+
+First the using statement needs to be added to the top of your *MauiProgram.cs* file
+
+```csharp
+using CommunityToolkit.Maui.Maps;
+```
+
+In order to use the `Map` correctly the `.UseMauiCommunityToolkitMaps` method must be called on the `MauiAppBuilder` class when bootstrapping an application the *MauiProgram.cs* file. This method expects a valid Bing Maps API key which you can obtain through the [Bing Maps Portal](https://www.bingmapsportal.com/).
+
+The following example shows how to perform this.
+
+```csharp
+var builder = MauiApp.CreateBuilder();
+builder
+    .UseMauiApp<App>()
+    .UseMauiCommunityToolkitMaps("YOUR_API_KEY")
+```
+
+How to initialize the map on iOS and Android, as well as how to work with the map control API, see the [.NET MAUI Maps documentation](/dotnet/maui/user-interface/controls/map).
+
 ### [CommunityToolkit.Maui.MediaElement](#tab/CommunityToolkitMauiMediaElement)
 
 This package enables you to play audio and video in your .NET MAUI application.

--- a/docs/maui/views/Map.md
+++ b/docs/maui/views/Map.md
@@ -1,0 +1,22 @@
+---
+title: Map - .NET MAUI Community Toolkit
+author: jfversluis
+description: "The Map control is a cross-platform view for displaying and annotating maps. The Windows implementation is available through the .NET MAUI Community Toolkit."
+ms.date: 13/06/2023
+---
+
+# Map
+
+The `Map` control is a cross-platform view for displaying and annotating maps. The Windows implementation is available through the .NET MAUI Community Toolkit.
+
+## Setup
+
+Before you are able to use `Map` inside your application you will need to install the NuGet package and add an initialization line in your *MauiProgram.cs*. For more information on how to do this, please refer to the [Get Started](../get-started.md) page.
+
+## Examples
+
+You can find examples of this control in action in the [.NET MAUI Community Toolkit Sample Application](https://github.com/CommunityToolkit/Maui/tree/main/samples/CommunityToolkit.Maui.Sample/Pages/Views/Maps).
+
+## API
+
+You can find the source code for `Map` over on the [.NET MAUI Community Toolkit GitHub repository](https://github.com/CommunityToolkit/Maui/blob/main/src/CommunityToolkit.Maui.Maps/AppHostBuilderExtensions.shared.cs).

--- a/docs/maui/views/Map.md
+++ b/docs/maui/views/Map.md
@@ -2,7 +2,7 @@
 title: Map - .NET MAUI Community Toolkit
 author: jfversluis
 description: "The Map control is a cross-platform view for displaying and annotating maps. The Windows implementation is available through the .NET MAUI Community Toolkit."
-ms.date: 13/06/2023
+ms.date: 06/13/2023
 ---
 
 # Map

--- a/docs/maui/views/Map.md
+++ b/docs/maui/views/Map.md
@@ -13,6 +13,12 @@ The `Map` control is a cross-platform view for displaying and annotating maps. T
 
 Before you are able to use `Map` inside your application you will need to install the NuGet package and add an initialization line in your *MauiProgram.cs*. For more information on how to do this, please refer to the [Get Started](../get-started.md) page.
 
+## Usage
+
+The API of the .NET MAUI Community Toolkit implementation for Windows is not different from the API of the .NET MAUI Maps implementation for iOS and Android.
+
+For details on how to work with this map control, please refer to the [.NET MAUI Map documentation](/dotnet/maui/user-interface/controls/map).
+
 ## Examples
 
 You can find examples of this control in action in the [.NET MAUI Community Toolkit Sample Application](https://github.com/CommunityToolkit/Maui/tree/main/samples/CommunityToolkit.Maui.Sample/Pages/Views/Maps).

--- a/docs/maui/views/index.md
+++ b/docs/maui/views/index.md
@@ -2,7 +2,7 @@
 title: Views - .NET MAUI Community Toolkit
 author: jfversluis
 description: The .NET MAUI Community Toolkit extends .NET MAUI controls.
-ms.date: 01/23/2023
+ms.date: 06/13/2023
 ---
 
 # Views
@@ -23,6 +23,7 @@ The .NET MAUI Community Toolkit provides a collection of pre-built, reusable vie
 | [`DrawingView`](DrawingView.md) | The `DrawingView` provides a surface that allows for the drawing of lines through the use of touch or mouse interaction. The result of a users drawing can be saved out as an image. |
 | [`Expander`](Expander.md) | The `Expander` control provides an expandable container to host any content. |
 | [`LazyView`](LazyView.md) | The `LazyView` control allows you to delay the initialization of a View.|
+| [`Map (Windows)`](Map.md) | The `Map` control is a cross-platform view for displaying and annotating maps. The Windows implementation is available through the .NET MAUI Community Toolkit. |
 | [`MediaElement`](MediaElement.md) | The `MediaElement` is a view for playing multimedia such as audio and video. |
 | [`Popup`](popup.md) | The `Popup` view allows developers to build their own custom UI and present it to their users. |
 | [`SemanticOrderView`](semantic-order-view.md) | The `SemanticOrderView` provides the ability to control the order of VisualElements for screen readers and improve the Accessibility of an application. |


### PR DESCRIPTION
Adds some brief documentation for the .NET MAUI Community Toolkit Windows Maps. Basically the get started as that is an extra step from the regular .NET MAUI Maps and then refer to the .NET MAUI documentation for the actual APIs.