### PR TITLE
More clearly state which NuGet is needed for MediaElement

### DIFF
--- a/docs/maui/views/MediaElement.md
+++ b/docs/maui/views/MediaElement.md
@@ -45,7 +45,7 @@ The supported multimedia formats can be different per platform. In some cases it
 
 ## Setup
 
-Before you are able to use `MediaElement` inside your application you will need to install the NuGet package and add an initialization line in your *MauiProgram.cs*. For more information on how to do this, please refer to the [Get Started](../get-started.md) page.
+Before you are able to use `MediaElement` inside your application you will need to install the `CommunityToolkit.Maui.MediaElement` NuGet package and add an initialization line in your *MauiProgram.cs*. For more information on how to do this, please refer to the [Get Started](../get-started.md#communitytoolkitmauimediaelement) page.
 
 ### Including the XAML namespace
 


### PR DESCRIPTION
Adds a little bit clearer which package is needed for MediaElement and links to the right tab on the Getting Started page.

Fixes #301