### PR TITLE
Fix breadcrumbs

### DIFF
--- a/docs/breadcrumb/toc.yml
+++ b/docs/breadcrumb/toc.yml
@@ -1,4 +1,3 @@
-items:
 - name: Docs
   tocHref: /
   topicHref: /
@@ -6,20 +5,3 @@ items:
   - name: .NET
     tocHref: /dotnet/
     topicHref: /dotnet/index
-    items:
-    - name: Community Toolkits for .NET
-      tocHref: /dotnet/communitytoolkit/
-      topicHref: /dotnet/communitytoolkit/index
-      items:
-        - name: .NET Community Toolkit Introduction
-          tocHref: /dotnet/communitytoolkit/
-          topicHref: /dotnet/communitytoolkit/introduction
-        - name: MVVM Toolkit
-          tocHref: /dotnet/communitytoolkit/mvvm/
-          topicHref: /dotnet/communitytoolkit/mvvm/index
-        - name: .NET MAUI Community Toolkit
-          tocHref: /dotnet/communitytoolkit/maui/
-          topicHref: /dotnet/communitytoolkit/maui/index
-        - name: Windows Community Toolkit
-          tocHref: /dotnet/communitytoolkit/windows/
-          topicHref: /dotnet/communitytoolkit/windows/index

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -45,7 +45,6 @@
       "uhfHeaderId": "MSDocsHeader-DotNet",
       "author": "jfversluis",
       "breadcrumb_path": "/dotnet/communitytoolkit/breadcrumb/toc.json",
-      "extendBreadcrumb": true,
       "feedback_system": "GitHub",
       "feedback_github_repo": "MicrosoftDocs/CommunityToolkit",
       "feedback_product_url": "https://github.com/CommunityToolkit/",


### PR DESCRIPTION
This PR brings breadcrumb implementation into alignment with [platform architecture requirements](https://review.learn.microsoft.com/en-us/help/platform/navigation-overview?branch=main#requirements-for-content-ecosystems). This PR is part of a previously announced batch of breadcrumb fixes across the Learn platform and will be auto-merged if there are no build warnings. This PR may include removing the “extend breadcrumb” feature from any docfx files that are still using it, fixing breadcrumb file references in the docfx file, and rewriting breadcrumb files to match the [approved breadcrumb pattern](https://review.learn.microsoft.com/en-us/help/platform/navigation-breadcrumbs-overview?branch=main#breadcrumbs-in-documentation) for a given product’s documentation.