### PR TITLE
Update Link to ExoPlayer in MediaElement.md

### DIFF
--- a/docs/maui/views/MediaElement.md
+++ b/docs/maui/views/MediaElement.md
@@ -35,7 +35,7 @@ The supported multimedia formats can be different per platform. In some cases it
 
 |Platform| Link | Notes |
 |--------|------|-------|
-| Android | [ExoPlayer Supported Formats](https://exoplayer.dev/supported-formats.html) | |
+| Android | [ExoPlayer Supported Formats](https://developer.android.com/guide/topics/media/exoplayer/supported-formats) | |
 | iOS/macOS | [iOS/macOS Supported Formats](https://stackoverflow.com/a/45898816/1506387) | No official documentation on this exists |
 | Windows | [Windows Supported Formats](/windows/uwp/audio-video-camera/supported-codecs) | On Windows the supported formats are very much dependent on what codecs are installed on the user's machine |
 | Tizen | [Tizen Supported Formats](https://docs.tizen.org/application/native/tutorials/feature/app-multimedia-video) | |


### PR DESCRIPTION
The link to the ExoPlayer Documentation was according to the content of its page out of date and developer.android.com was recommended instead. 
Here is the message that is shown for the current link:   
![image](https://github.com/MicrosoftDocs/CommunityToolkit/assets/66683631/e925e145-cd3b-45d4-b701-4dd3b0c0b059)
