### PR TITLE
Update variable-multi-value-converter.md

### DIFF
--- a/docs/maui/converters/variable-multi-value-converter.md
+++ b/docs/maui/converters/variable-multi-value-converter.md
@@ -129,7 +129,7 @@ class VariableMultiValueConverterPage : ContentPage
 |Property  |Type  |Description  |
 |---------|---------|---------|
 | ConditionType | `MultiBindingCondition` | Indicates how many values should be `true` out of the provided boolean values in the `MultiBinding`. |
-| Count | `int` | The number of values that should be true when using `ConditionType` of `GreaterThan`, `LessThan` or `Exact`. |
+| Count | `int` | The value to evaluate the condition upon when using `ConditionType` of `GreaterThan`, `LessThan` or `Exact`. |
 
 ### MultiBindingCondition
 


### PR DESCRIPTION
- Corrected the description of the "Count" property, as it was completely false, probably due to a copy-paste mistake.
- This property should not have been called "Count" in the first place. "Value" would be much more appropriate.