### PR TITLE
update SelectAllTextBehavior doc to explain .net non-runtime issue

### DIFF
--- a/docs/maui/behaviors/select-all-text-behavior.md
+++ b/docs/maui/behaviors/select-all-text-behavior.md
@@ -11,6 +11,9 @@ The `SelectAllTextBehavior` is a [`Behavior`](/dotnet/maui/fundamentals/behavior
 
 [!INCLUDE [important note on bindings within behaviors](../includes/behavior-bindings.md)]
 
+> [!IMPORTANT]
+> `SelectAllTextBehavior` is a platform specific behavior. It has an implementation in all runtime types supported by `Maui` but cannot be referenced by a project that targets .NET without a native runtime. If the project compiles for .NET only, you will receive the error `The type 'toolkit:SelectAllTextBehavior' was not found.`
+
 ## Syntax
 
 The following examples show how to add the `SelectAllTextBehavior` to an `Entry`.


### PR DESCRIPTION
The SelectAllTextBehavior cannot be referenced from a project that runs .NET without a native runtime. Because of the way unit tests run in Maui, it's common to have a version of .NET as the target framework. Adding a note at the top of the document could save someone from implementing it in a project that is .NET only.