### PR TITLE
Fully qualify AVAudioSession in sample code

### DIFF
--- a/docs/maui/views/MediaElement.md
+++ b/docs/maui/views/MediaElement.md
@@ -128,8 +128,8 @@ public static class MauiProgram
     {
         // ... Additonal Code Not Shown ... //
 #if IOS
-        AVAudioSession.SharedInstance().SetActive(true);
-        AVAudioSession.SharedInstance().SetCategory(AVAudioSessionCategory.Playback);
+        AVFoundation.AVAudioSession.SharedInstance().SetActive(true);
+        AVFoundation.AVAudioSession.SharedInstance().SetCategory(AVAudioSessionCategory.Playback);
 #endif
         // ... Additonal Code Not Shown ... //
     }


### PR DESCRIPTION
The sample code for handling the silent switch on iDevices didn't compile as-is.

This PR fully qualifies the type names so that it's more clear what the full solution is in this case.

Fixes #417