### PR TITLE
Mark include files as include files

### DIFF
--- a/docs/maui/includes/behavior-bindings.md
+++ b/docs/maui/includes/behavior-bindings.md
@@ -1,2 +1,6 @@
+---
+ms.topic: include
+---
+
 > [!IMPORTANT]
 > The .NET MAUI Community Toolkit Behaviors do not set the `BindingContext` of a behavior, because behaviors can be shared and applied to multiple controls through styles. For more information refer to [.NET MAUI Behaviors](/dotnet/maui/fundamentals/behaviors#net-maui-behaviors)

--- a/docs/maui/includes/communitytoolkit-converter.md
+++ b/docs/maui/includes/communitytoolkit-converter.md
@@ -1,3 +1,7 @@
+---
+ms.topic: include
+---
+
 ### BaseConverter Properties
 
 The following properties are implemented in the base class, `public abstract class BaseConverter`:

--- a/docs/maui/includes/math-expression-operations.md
+++ b/docs/maui/includes/math-expression-operations.md
@@ -1,3 +1,7 @@
+---
+ms.topic: include
+---
+
 ## Supported operations
 
 The following operations are supported:

--- a/docs/maui/includes/toast-snackbar-setup.md
+++ b/docs/maui/includes/toast-snackbar-setup.md
@@ -1,3 +1,7 @@
+---
+ms.topic: include
+---
+
 <!-- markdownlint-disable MD025 -->
 ### [Android](#tab/android)
 
@@ -63,7 +67,7 @@ Here is an example of a completed opening `<Package>` tag that has added support
 
    <!-- Specify which CLSID to activate when notification is clicked -->
    <desktop:Extension Category="windows.toastNotificationActivation">
-       <desktop:ToastNotificationActivation ToastActivatorCLSID="6e919706-2634-4d97-a93c-2213b2acc334" /> 
+       <desktop:ToastNotificationActivation ToastActivatorCLSID="6e919706-2634-4d97-a93c-2213b2acc334" />
    </desktop:Extension>
 
    <!-- Register COM CLSID -->
@@ -97,9 +101,9 @@ Here is an example of a completed `<Applications>` tag that now has added suppor
        <Extensions>
 
          <desktop:Extension Category="windows.toastNotificationActivation">
-             <desktop:ToastNotificationActivation ToastActivatorCLSID="6e919706-2634-4d97-a93c-2213b2acc334" /> 
+             <desktop:ToastNotificationActivation ToastActivatorCLSID="6e919706-2634-4d97-a93c-2213b2acc334" />
          </desktop:Extension>
-      
+
          <com:Extension Category="windows.comServer">
              <com:ComServer>
                  <com:ExeServer Executable="YOUR-PATH-TO-EXECUTABLE" DisplayName="$targetnametoken$" Arguments="----AppNotificationActivated:"> <!-- Example path to executable: CommunityToolkit.Maui.Sample\CommunityToolkit.Maui.Sample.exe -->
@@ -158,9 +162,9 @@ Below is an example `Package.appxmanifest` file that has been updated to support
             <Extensions>
 
                <desktop:Extension Category="windows.toastNotificationActivation">
-                   <desktop:ToastNotificationActivation ToastActivatorCLSID="6e919706-2634-4d97-a93c-2213b2acc334" /> 
+                   <desktop:ToastNotificationActivation ToastActivatorCLSID="6e919706-2634-4d97-a93c-2213b2acc334" />
                </desktop:Extension>
-            
+
                <com:Extension Category="windows.comServer">
                    <com:ComServer>
                        <com:ExeServer Executable="YOUR-PATH-TO-EXECUTABLE" DisplayName="$targetnametoken$" Arguments="----AppNotificationActivated:"> <!-- Example path to executable: CommunityToolkit.Maui.Sample\CommunityToolkit.Maui.Sample.exe -->

--- a/docs/maui/includes/validation-behavior.md
+++ b/docs/maui/includes/validation-behavior.md
@@ -1,3 +1,7 @@
+---
+ms.topic: include
+---
+
 ### ValidationBehavior Properties
 
 The following properties are implemented in the base class, `public abstract class ValidationBehavior`:

--- a/docs/maui/includes/xaml-usage.md
+++ b/docs/maui/includes/xaml-usage.md
@@ -1,3 +1,7 @@
+---
+ms.topic: include
+---
+
 In order to use the toolkit in XAML the following `xmlns` needs to be added into your page or view:
 
 ```xaml


### PR DESCRIPTION
Mark include files as include files, so that they aren't also built as unique docs in their own right.