### PR TITLE
Typo in Camera documentation for Stop Preview: issue #444

### DIFF
--- a/docs/maui/views/camera-view.md
+++ b/docs/maui/views/camera-view.md
@@ -462,7 +462,7 @@ The following example shows how to add a `Button` into the application and setup
 
 ## Stop preview
 
-The `CameraView` provides the ability to programmatically start the preview from the camera. This is possible through both the `StopCameraPreview` method or the `StopCameraPreviewCommand`.
+The `CameraView` provides the ability to programmatically stop the preview from the camera. This is possible through both the `StopCameraPreview` method or the `StopCameraPreviewCommand`.
 
 The following example shows how to add a `Button` into the application and setup the following bindings:
 


### PR DESCRIPTION
Typo in Camera documentation for Stop Preview.

See #444  for details.

Current copy:
The CameraView provides the ability to programmatically **start** the preview from the camera. This is possible through both the StopCameraPreview method or the StopCameraPreviewCommand.

Expected copy:
The CameraView provides the ability to programmatically **stop** the preview from the camera. This is possible through both the StopCameraPreview method or the StopCameraPreviewCommand.