### PR TITLE
Use Collection Expressions for Complex (Nested) Bindings

### DIFF
--- a/docs/maui/markup/extensions/bindable-object-extensions.md
+++ b/docs/maui/markup/extensions/bindable-object-extensions.md
@@ -54,11 +54,11 @@ Using the below `ViewModel` class, we can create a nested two-way binding direct
 new Entry().Bind(
     Entry.TextProperty,
     getter: static (ViewModel vm) => vm.NestedObject.Text,
-    handlers: new (Func<ViewModel, object?>, string)[]
-             {
-                (vm => vm, nameof(ViewModel.NestedObject)),
-                (vm => vm.NestedObject, nameof(ViewModel.NestedObject.Text)),
-             },
+    handlers: 
+    [
+        (vm => vm, nameof(ViewModel.NestedObject)),
+        (vm => vm.NestedObject, nameof(ViewModel.NestedObject.Text)),
+    ],
     setter: static (ViewModel vm, string text) => vm.NestedObject.Text = text);
 ```
 


### PR DESCRIPTION
This PR simplifies the initialization syntax of Complex (Nested) Bindings, leveraging Collection Expressions. 

It also provides a small performance improvement as the Compiled Expression always compiles down to the most efficient code. Here is the compiler output for the Collection Expression used in this example in the docs:
```cs
new ValueTuple<Func<ViewModel, object>, string>[2]
{
  new ValueTuple<Func<ViewModel, object>, string>((Func<ViewModel, object>)((ViewModel vm) => vm), "NestedObject"),
  new ValueTuple<Func<ViewModel, object>, string>((Func<ViewModel, object>)((ViewModel vm) => vm. NestedObject), "Text")
},
```