### PR TITLE
Update MacOS instructions for Plist manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ _repo.*/
 
 .openpublishing.buildcore.ps1
 .DS_Store
+/.vs

--- a/docs/maui/views/MediaElement.md
+++ b/docs/maui/views/MediaElement.md
@@ -135,6 +135,23 @@ For a full example of this method included in an application please refer to the
 
 Edit the `Info.plist` for `MacCatalyst` and add the following keys.
 ```csharp
+<key>UIApplicationSceneManifest</key>
+	<dict>
+        <key>UIApplicationSupportsMultipleScenes</key>
+        <true/>
+        <key>UISceneConfigurations</key>
+        <dict>
+            <key>UIWindowSceneSessionRoleApplication</key>
+            <array>
+            <dict>
+                <key>UISceneConfigurationName</key>
+                <string>__MAUI_DEFAULT_SCENE_CONFIGURATION__</string>
+                <key>UISceneDelegateClassName</key>
+                <string>SceneDelegate</string>
+            </dict>
+            </array>
+        </dict>
+    </dict>
 <key>UIBackgroundModes</key>
 <array>
     <string>bluetooth-central</string>


### PR DESCRIPTION
Updated .gitignore to ignore the .vs directory used by Visual Studio. Expanded MediaElement.md with detailed instructions for editing the Info.plist file to support multiple scenes in Mac Catalyst applications. Added keys include UIApplicationSceneManifest, UIApplicationSupportsMultipleScenes, and UISceneConfigurations with their respective configurations.