### PR TITLE
Update `CommunityToolkit.Maui.Markup` Docs for .NET 9

### DIFF
--- a/docs/maui/markup/extensions/bindable-object-extensions.md
+++ b/docs/maui/markup/extensions/bindable-object-extensions.md
@@ -89,6 +89,9 @@ new Entry().Bind(nameof(ViewModel.RegistrationCode))
 > [!WARNING]
 > This approach will result in some level of Reflection being used and will not perform as well as the [Explicit property](#inline-conversion) approach.
 
+> [!Warning]
+> Bindings like this that use a `string` for the `path:` parameter are not trim-safe
+
 #### Value conversion
 
 The `Bind` method allows for a developer to supply the `Converter` that they wish to use in the binding or simply provide a mechanism to use an inline conversion.
@@ -123,8 +126,8 @@ The `convert` parameter is a `Func` that is required to convert the multiple bin
 ```csharp
 new Label()
     .Bind(Label.TextProperty,
-            binding1: new Binding(nameof(ViewModel.IsBusy)),
-            binding2: new Binding(nameof(ViewModel.LabelText)),
+            binding1: BindingBase.Create((ViewModel vm) => vm.IsBusy),
+            binding2: BindingBase.Create((ViewModel vm) => vm.LabelText),
             convert: ((bool IsBusy, string LabelText) values) => values.IsBusy ? string.Empty : values.LabelText)
 ```
 

--- a/docs/maui/markup/extensions/text-alignment-extensions.md
+++ b/docs/maui/markup/extensions/text-alignment-extensions.md
@@ -39,6 +39,16 @@ Here's an example setting `Label.HorizontalTextAlignment` to `TextAlignment.End`
 new Label().TextEnd()
 ```
 
+## TextJustify
+
+The `TextJustify` method sets the `ITextAlignment.HorizontalTextAlignment` property to `TextAlignment.Justify`.
+
+Here's an example setting `Label.HorizontalTextAlignment` to `TextAlignment.Justify` using `TextJustify`:
+
+```cs
+new Label().TextJustify()
+```
+
 ## TextTop
 
 The `TextTop` method sets the `ITextAlignment.VerticalTextAlignment` property to `TextAlignment.Start`.


### PR DESCRIPTION
---

**DO NOT MERGE THIS UNTIL THIS PR ON `COMMUNITYTOOLKIT.MAUI.MARKUP` HAS BEEN MERGED: https://github.com/CommunityToolkit/Maui.Markup/pull/324**

---

This PR updates the `CommunityToolkit.Maui.Markup` docs for .NET 9. 

In .NET 9, using a `string` path for bindings is no longer supported. We've also removed all `[Obsoelete]` extension methods (e.g. `ClickGestureRecognizer`).