### PR TITLE
Set a global ms.date

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -45,7 +45,7 @@
       "uhfHeaderId": "MSDocsHeader-DotNet",
       "author": "jfversluis",
       "ms.author": "joverslu",
-      "ms.date" : "11/07/2024"
+      "ms.date" : "11/07/2024",
       "breadcrumb_path": "/dotnet/communitytoolkit/breadcrumb/toc.json",
       "feedback_system": "OpenSource",
       "feedback_github_repo": "MicrosoftDocs/CommunityToolkit",

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -45,6 +45,7 @@
       "uhfHeaderId": "MSDocsHeader-DotNet",
       "author": "jfversluis",
       "ms.author": "joverslu",
+      "ms.date" : "11/07/2024"
       "breadcrumb_path": "/dotnet/communitytoolkit/breadcrumb/toc.json",
       "feedback_system": "OpenSource",
       "feedback_github_repo": "MicrosoftDocs/CommunityToolkit",
@@ -55,7 +56,7 @@
       "open_source_feedback_productName": ".NET Community Toolkit",
       "open_source_feedback_productLogoLightUrl": "https://learn.microsoft.com/media/logos/logo_net.svg",
       "open_source_feedback_productLogoDarkUrl": "https://learn.microsoft.com/media/logos/logo_net.svg",
-      "ms.topic": "conceptual",      
+      "ms.topic": "conceptual",
       "ms.service": "dotnet-communitytoolkit",
       "titleSuffix": "Community Toolkits for .NET",
       "searchScope": [ "Community Toolkits for .NET" ]


### PR DESCRIPTION
This PR sets a global `ms.date` value so that every article in the docset has a valid `ms.date` value.