### PR TITLE
Fix method name in Guard API

### DIFF
--- a/docs/diagnostics/Guard.md
+++ b/docs/diagnostics/Guard.md
@@ -104,7 +104,7 @@ There are dozens of different APIs and overloads in the `Guard` class, here are 
 | Methods | Return Type | Description |
 | -- | -- | -- |
 | IsNotNullOrEmpty(string, string) | void | Asserts that the input string instance must not be null or empty |
-| IsNotNullOrWhitespace(string, string) | void | Asserts that the input string instance must not be null or whitespace |
+| IsNotNullOrWhiteSpace(string, string) | void | Asserts that the input string instance must not be null or whitespace |
 
 ### Collections
 


### PR DESCRIPTION
https://github.com/CommunityToolkit/dotnet/blob/657c6971a8d42655c648336b781639ed96c2c49f/src/CommunityToolkit.Diagnostics/Guard.String.cs#L76