### PR TITLE
Fixed typo with android:stopWithTask

### DIFF
--- a/docs/maui/views/MediaElement.md
+++ b/docs/maui/views/MediaElement.md
@@ -81,7 +81,7 @@ public class MainActivity : MauiAppCompatActivity
 #### 2. Add the following to `AndroidManifest.xml` inside the `<application>` tag.
 
 ```csharp
- <service android:name="communityToolkit.maui.media.services" android:stopWithTask android:exported="false" android:enabled="true" android:foregroundServiceType="mediaPlayback">
+ <service android:name="communityToolkit.maui.media.services" android:stopWithTask="true" android:exported="false" android:enabled="true" android:foregroundServiceType="mediaPlayback">
    <intent-filter>
      <action android:name="androidx.media3.session.MediaSessionService"/>
    </intent-filter>


### PR DESCRIPTION
android:stopWithTask requires `="true"` to work. This matches the full example further down.