### PR TITLE
Add minimum Android version requirements to MediaElement.md

### DIFF
--- a/docs/maui/views/MediaElement.md
+++ b/docs/maui/views/MediaElement.md
@@ -88,7 +88,13 @@ public class MainActivity : MauiAppCompatActivity
  </service>
 ```
 
-#### 3. Add the following permissions to `AndroidManifest.xml`
+#### 3. Update the minimum android API version
+In the project's `.csproj` file, update the minimum android API version to 26.
+```xml
+<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">26.0</SupportedOSPlatformVersion>
+```
+
+#### 4. Add the following permissions to `AndroidManifest.xml`
 
 ```csharp
 <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />


### PR DESCRIPTION
As seen in .NET MAUI's [2485](https://github.com/CommunityToolkit/Maui/issues/2485) bug ticket, this configuration can prevent a `Java.Lang.AbstractMethodError Message=abstract method "void androidx.media3.common.Player$Listener.onSurfaceSizeChanged(int, int)"` from crashing the app.