### PR TITLE
Correctly link to the index.md at the same level

### DIFF
--- a/docs/maui/native-library-interop/get-started.md
+++ b/docs/maui/native-library-interop/get-started.md
@@ -31,7 +31,7 @@ Install prerequisites:
 
 ## Create a new binding
 
-The easiest way to get started with creating a new binding is by cloning the **template** in the **[Maui.NativeLibraryInterop](https://github.com/CommunityToolkit/Maui.NativeLibraryInterop)** repo and making modifications from there. To better understand the full scope of how Maui.NativeLibraryInterop is currently set up, read more in the [overview documentation](../index.md).
+The easiest way to get started with creating a new binding is by cloning the **template** in the **[Maui.NativeLibraryInterop](https://github.com/CommunityToolkit/Maui.NativeLibraryInterop)** repo and making modifications from there. To better understand the full scope of how Maui.NativeLibraryInterop is currently set up, read more in the [overview documentation](./index.md).
 
 ### Set up the .NET binding libraries
 


### PR DESCRIPTION
Points the overview link to index.md in the native interop folder rather than the MAUI Community Toolkit.