### PR TITLE
Update MediaElement.md about the end of need for manual handler disconnection 

### DIFF
--- a/docs/maui/views/MediaElement.md
+++ b/docs/maui/views/MediaElement.md
@@ -351,42 +351,6 @@ In this example, the [`Slider`](xref:Microsoft.Maui.Controls.Slider) data binds 
 
 For more information about using a [`Slider`](xref:Microsoft.Maui.Controls.Slider) see, [.NET MAUI Slider](/dotnet/maui/user-interface/controls/slider)
 
-## Clean up `MediaElement` resources
-
-To prevent memory leaks you will have to free the resources of `MediaElement`. This can be done by disconnecting the handler.
-Where you need to do this is dependant on where and how you use `MediaElement` in your app, but typically if you have a `MediaElement` on a single page and are not playing media in the background, you want to free the resources when the user navigates away from the page.
-
-Below you can find a snippet of sample code which shows how to do this. First, make sure to hook up the `Unloaded` event on your page.
-
-```xaml
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
-             x:Class="MediaElementDemos.FreeResourcesPage"
-             Title="Free Resources"
-             Unloaded="ContentPage_Unloaded">
-    
-    <toolkit:MediaElement x:Name="mediaElement"
-                          ShouldAutoPlay="False"
-                          ... />
-</ContentPage>
-```
-
-Then in the code-behind, call the method to disconnect the handler.
-
-```csharp
-public partial class FreeResourcesPage : ContentPage
-{
-    void ContentPage_Unloaded(object? sender, EventArgs e)
-    {
-        // Stop and cleanup MediaElement when we navigate away
-        mediaElement.Handler?.DisconnectHandler();
-    }
-}
-```
-
-To read more about handlers, please see the .NET MAUI documentation on [Handlers](/dotnet/maui/user-interface/handlers).
-
 ## Properties
 
 |Property  |Type  |Description  |Default Value  |


### PR DESCRIPTION
As far as I've understand from @ne0rrmatrix [#2656 PR in MCT's repo](https://github.com/CommunityToolkit/Maui/pull/2656) this part is no longer required in the docs as well