### PR TITLE
Fix presentation of DialogFragment

### DIFF
--- a/docs/maui/TOC.yml
+++ b/docs/maui/TOC.yml
@@ -215,6 +215,8 @@ items:
   items:
     - name: Overview
       href: platform-specific/index.md
+    - name: "DialogFragment (Android)"
+      href: platform-specific/DialogFragment-customization.md
     - name: "Navigation Bar (Android)"
       href: platform-specific/navigation-bar.md
 - name: "Views"

--- a/docs/maui/platform-specific/index.md
+++ b/docs/maui/platform-specific/index.md
@@ -12,3 +12,4 @@ The .NET MAUI Community Toolkit provides a set of platform specific features as 
 | Feature | Description |
 | --------- | ----------- |
 | [`Android NavigationBar`](navigation-bar.md) | The `NavigationBar` provides the ability to customize the appearance of the Navigation Bar on the Android platform. |
+| [`DialogFragment customization`](DialogFragment-customization.md) | The `DialogFragment` is Android's view used to show modal pages, and if you want to access its platform APIs and lifecycle this is the best place to hook into.


### PR DESCRIPTION
Before this PR the `DialogFragment-customization.md` docs isn't shown into menus on the site, so it's hard to discover it. This PR fix that