### PR TITLE
Fix tab behavior in Toast and Snackbar docs

### DIFF
--- a/docs/maui/alerts/snackbar.md
+++ b/docs/maui/alerts/snackbar.md
@@ -54,11 +54,11 @@ await snackbar.Show(cancellationTokenSource.Token);
 When calling `Snackbar.Make()`, its parameter `string text` is required. All other parameters are optional.
 
 The following screenshot shows the resulting Snackbar:
-# [Android](#tab/android)
+# [Android](#tab/snackbar-preview-android)
 
 ![Screenshot of an Snackbar on Android](../images/alerts/snackbar-android.gif "Snackbar on Android")
 
-# [iOS](#tab/ios)
+# [iOS](#tab/snackbar-preview-ios)
 
 ![Screenshot of an Snackbar on iOS](../images/alerts/snackbar-ios.gif "Snackbar on iOS")
 

--- a/docs/maui/alerts/toast.md
+++ b/docs/maui/alerts/toast.md
@@ -40,11 +40,11 @@ await toast.Show(cancellationTokenSource.Token);
 When calling `Toast.Make()`, its parameter `string text` is required. All other parameters are optional. Its optional parameter `ToastDuration duration` uses the default duration of `ToastDuration.Short`. Its optional parameter `double fontSize` uses the default value of `14.0`.
 
 The following screenshot shows the resulting Toast:
-### [Android](#tab/android)
+### [Android](#tab/toast-preview-android)
 
 ![Screenshot of an Toast on Android](../images/alerts/toast-android.gif "Toast on Android")
 
-### [iOS](#tab/ios)
+### [iOS](#tab/toast-preview-ios)
 
 ![Screenshot of an Toast on iOS](../images/alerts/toast-ios.gif "Toast on iOS")
 


### PR DESCRIPTION
## Summary
This PR fixes tab behavior issues in the MAUI Alerts docs by preventing tab state collisions between unrelated tab groups on the same page.

## Root cause
Both pages reuse platform tab IDs across multiple tab groups with different membership counts, which can cause Learn to apply mixed or locked tab selections.

## Changes
- Updated screenshot preview tab IDs in docs/maui/alerts/toast.md to unique IDs:
  - toast-preview-android
  - toast-preview-ios
- Updated screenshot preview tab IDs in docs/maui/alerts/snackbar.md to unique IDs:
  - snackbar-preview-android
  - snackbar-preview-ios

## Issues
- Closes #429
- Closes #437