### PR TITLE
Fix OnSelectedItemChanging example

### DIFF
--- a/docs/mvvm/generators/ObservableProperty.md
+++ b/docs/mvvm/generators/ObservableProperty.md
@@ -100,7 +100,7 @@ partial void OnSelectedItemChanging(ChildViewModel? oldValue, ChildViewModel? ne
 {
     if (oldValue is not null)
     {
-        oldValue.IsSelected = true;
+        oldValue.IsSelected = false;
     }
 
     if (newValue is not null)


### PR DESCRIPTION
While technically being valid code, it's nonsensical to use "OnSelectedItemChanging" to set both old and new value to "true" instead of old value to "false" and new value to "true".