### PR TITLE
Update heading for 'Get started' section

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -21,7 +21,7 @@ The toolkit contains .NET Standard libraries (originally developed as part of th
 
 You can also preview the capabilities of the [MVVM Toolkit](mvvm/index.md) by running the [sample app](https://aka.ms/mvvmtoolkit/samples).
 
-## [Get started][get-started]
+## Get started
 
 For more detailed information about using the toolkit, follow the [Getting started guide](/windows/communitytoolkit/getting-started).
 


### PR DESCRIPTION
Fix formatting - currently this is showing unformatted

<img width="678" height="155" alt="image" src="https://github.com/user-attachments/assets/b6416d7f-447f-4cb8-8c7e-e8c0d55cae98" />
