### PR TITLE
Add documentation for Guard.IsDefined enum validation

### DIFF
--- a/docs/diagnostics/Guard.md
+++ b/docs/diagnostics/Guard.md
@@ -106,6 +106,12 @@ There are dozens of different APIs and overloads in the `Guard` class. The follo
 | `IsNotNullOrEmpty(string, string)` | void        | Asserts that the input string instance must not be null or empty |
 | `IsNotNullOrWhiteSpace(string, string)` | void | Asserts that the input string instance must not be null or whitespace |
 
+### Enums
+
+| Methods                       | Return type | Description |
+|-------------------------------|-------------|-------------|
+| `IsDefined<T>(T, string)`     | void        | Asserts that the input enum value is defined in the enum type |
+
 ### Collections
 
 | Methods                               | Return type | Description |


### PR DESCRIPTION
Added some small documentation to the Guard page for [this implementation](https://github.com/CommunityToolkit/dotnet/pull/1210).